### PR TITLE
[codex] Implement entities, overrides, and system climate

### DIFF
--- a/custom_components/multi_zone_heating/__init__.py
+++ b/custom_components/multi_zone_heating/__init__.py
@@ -5,9 +5,9 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, TypeAlias
 
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, ServiceCall
 
-from .const import PLATFORMS
+from .const import DOMAIN, PLATFORMS
 from .models import RuntimeData
 from .coordinator import MultiZoneHeatingCoordinator, integration_config_from_dict
 
@@ -23,13 +23,29 @@ async def async_setup_entry(
     entry: MultiZoneHeatingConfigEntry,
 ) -> bool:
     """Set up multi_zone_heating from a config entry."""
+    domain_data: dict[str, RuntimeData] = hass.data.setdefault(DOMAIN, {})
     config = integration_config_from_dict(entry.data)
     coordinator = MultiZoneHeatingCoordinator(hass, config, config_entry=entry)
     entry.runtime_data = RuntimeData(
         config_entry_id=entry.entry_id,
+        title=entry.title,
         config=config,
         coordinator=coordinator,
     )
+    domain_data[entry.entry_id] = entry.runtime_data
+
+    if not hass.services.has_service(DOMAIN, "clear_override"):
+
+        async def _async_handle_clear_override(_call: ServiceCall) -> None:
+            """Clear overrides across loaded integration entries."""
+            await _async_clear_overrides(hass)
+
+        hass.services.async_register(
+            DOMAIN,
+            "clear_override",
+            _async_handle_clear_override,
+        )
+
     await coordinator.async_start()
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
     return True
@@ -45,4 +61,14 @@ async def async_unload_entry(
         coordinator = entry.runtime_data.coordinator
         if coordinator is not None:
             await coordinator.async_stop()
+        hass.data.get(DOMAIN, {}).pop(entry.entry_id, None)
+        if not hass.data.get(DOMAIN):
+            hass.services.async_remove(DOMAIN, "clear_override")
     return unloaded
+
+
+async def _async_clear_overrides(hass: HomeAssistant) -> None:
+    """Clear runtime overrides for all loaded entries."""
+    for runtime_data in hass.data.get(DOMAIN, {}).values():
+        if runtime_data.coordinator is not None:
+            await runtime_data.coordinator.async_clear_global_override()

--- a/custom_components/multi_zone_heating/binary_sensor.py
+++ b/custom_components/multi_zone_heating/binary_sensor.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from homeassistant.components.binary_sensor import BinarySensorEntity
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
@@ -11,7 +12,7 @@ from .const import DOMAIN
 
 
 async def async_setup_entry(
-    hass,
+    hass: HomeAssistant,
     entry: MultiZoneHeatingConfigEntry,
     async_add_entities: AddEntitiesCallback,
 ) -> None:

--- a/custom_components/multi_zone_heating/binary_sensor.py
+++ b/custom_components/multi_zone_heating/binary_sensor.py
@@ -2,17 +2,94 @@
 
 from __future__ import annotations
 
-from collections.abc import Callable
-from typing import Any
-
-from homeassistant.core import HomeAssistant
+from homeassistant.components.binary_sensor import BinarySensorEntity
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from . import MultiZoneHeatingConfigEntry
+from .const import DOMAIN
 
 
 async def async_setup_entry(
-    hass: HomeAssistant,
+    hass,
     entry: MultiZoneHeatingConfigEntry,
-    async_add_entities: Callable[[list[Any]], None],
+    async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up binary sensors for a config entry."""
+    runtime_data = entry.runtime_data
+    coordinator = runtime_data.coordinator
+    if coordinator is None:
+        return
+
+    entities: list[BinarySensorEntity] = [
+        MultiZoneHeatingSystemDemandBinarySensor(entry),
+        *[
+            MultiZoneHeatingZoneDemandBinarySensor(entry, zone.name)
+            for zone in runtime_data.config.zones
+        ],
+    ]
+    async_add_entities(entities)
+
+
+class MultiZoneHeatingBinarySensorBase(CoordinatorEntity, BinarySensorEntity):
+    """Base binary sensor for coordinator-backed integration entities."""
+
+    _attr_has_entity_name = True
+
+    def __init__(self, entry: MultiZoneHeatingConfigEntry) -> None:
+        """Initialize the entity."""
+        super().__init__(entry.runtime_data.coordinator)
+        self._entry = entry
+        self._attr_unique_id = None
+
+    @property
+    def available(self) -> bool:
+        """Return whether coordinator data is available."""
+        return self.coordinator.data is not None
+
+    @property
+    def device_info(self) -> dict[str, object]:
+        """Describe the integration device that owns these entities."""
+        return {
+            "identifiers": {(DOMAIN, self._entry.entry_id)},
+            "name": self._entry.title,
+        }
+
+
+class MultiZoneHeatingSystemDemandBinarySensor(MultiZoneHeatingBinarySensorBase):
+    """Binary sensor exposing aggregate demand."""
+
+    def __init__(self, entry: MultiZoneHeatingConfigEntry) -> None:
+        """Initialize the entity."""
+        super().__init__(entry)
+        self._attr_name = "System Demand"
+        self._attr_unique_id = f"{entry.entry_id}_system_demand"
+
+    @property
+    def is_on(self) -> bool | None:
+        """Return whether any zone currently demands heat."""
+        if self.coordinator.data is None:
+            return None
+        return self.coordinator.data.system_demand
+
+
+class MultiZoneHeatingZoneDemandBinarySensor(MultiZoneHeatingBinarySensorBase):
+    """Binary sensor exposing demand for one configured zone."""
+
+    def __init__(self, entry: MultiZoneHeatingConfigEntry, zone_name: str) -> None:
+        """Initialize the entity."""
+        super().__init__(entry)
+        self._zone_name = zone_name
+        self._attr_name = f"{zone_name} Demand"
+        self._attr_unique_id = f"{entry.entry_id}_{zone_name}_demand"
+
+    @property
+    def is_on(self) -> bool | None:
+        """Return whether the zone currently demands heat."""
+        if self.coordinator.data is None:
+            return None
+
+        for evaluation in self.coordinator.data.zone_evaluations:
+            if evaluation.name == self._zone_name:
+                return evaluation.demand
+        return None

--- a/custom_components/multi_zone_heating/climate.py
+++ b/custom_components/multi_zone_heating/climate.py
@@ -2,17 +2,157 @@
 
 from __future__ import annotations
 
-from collections.abc import Callable
 from typing import Any
 
-from homeassistant.core import HomeAssistant
+from homeassistant.components.climate import (
+    ClimateEntity,
+    ClimateEntityFeature,
+    HVACAction,
+    HVACMode,
+)
+from homeassistant.const import UnitOfTemperature
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from . import MultiZoneHeatingConfigEntry
+from .const import DOMAIN
 
 
 async def async_setup_entry(
-    hass: HomeAssistant,
+    hass,
     entry: MultiZoneHeatingConfigEntry,
-    async_add_entities: Callable[[list[Any]], None],
+    async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up climate entities for a config entry."""
+    if entry.runtime_data.coordinator is None:
+        return
+    async_add_entities([MultiZoneHeatingSystemClimate(entry)])
+
+
+class MultiZoneHeatingSystemClimate(CoordinatorEntity, ClimateEntity):
+    """Top-level climate entity for system-wide override control."""
+
+    _attr_has_entity_name = True
+    _attr_hvac_modes = [HVACMode.HEAT, HVACMode.OFF]
+    _attr_supported_features = ClimateEntityFeature.TARGET_TEMPERATURE
+    _attr_target_temperature_step = 0.5
+    _attr_temperature_unit = UnitOfTemperature.CELSIUS
+
+    def __init__(self, entry: MultiZoneHeatingConfigEntry) -> None:
+        """Initialize the climate entity."""
+        super().__init__(entry.runtime_data.coordinator)
+        self._entry = entry
+        self._attr_name = "System"
+        self._attr_unique_id = f"{entry.entry_id}_system_climate"
+
+    @property
+    def available(self) -> bool:
+        """Return whether coordinator data is available."""
+        return self.coordinator.data is not None
+
+    @property
+    def device_info(self) -> dict[str, object]:
+        """Describe the integration device that owns these entities."""
+        return {
+            "identifiers": {(DOMAIN, self._entry.entry_id)},
+            "name": self._entry.title,
+        }
+
+    @property
+    def hvac_mode(self) -> HVACMode | None:
+        """Return the effective HVAC mode."""
+        if self.coordinator.data is None:
+            return None
+        return HVACMode.OFF if self.coordinator.data.global_force_off else HVACMode.HEAT
+
+    @property
+    def hvac_action(self) -> HVACAction | None:
+        """Return whether the system is heating right now."""
+        data = self.coordinator.data
+        if data is None:
+            return None
+        if data.global_force_off:
+            return HVACAction.OFF
+        return HVACAction.HEATING if data.system_demand else HVACAction.IDLE
+
+    @property
+    def target_temperature(self) -> float | None:
+        """Return the displayed target temperature."""
+        data = self.coordinator.data
+        if data is None:
+            return None
+        if data.global_override is not None and data.global_override.active:
+            return data.global_override.target_temperature
+        for target_temperature in data.target_temperatures.values():
+            if target_temperature is not None:
+                return target_temperature
+        return None
+
+    @property
+    def current_temperature(self) -> float | None:
+        """Return the mean visible zone temperature when available."""
+        data = self.coordinator.data
+        if data is None:
+            return None
+
+        temperatures: list[float] = []
+        for evaluation in data.zone_evaluations:
+            if evaluation.current_temperature is not None:
+                temperatures.append(evaluation.current_temperature)
+            for group in evaluation.local_groups:
+                if group.current_temperature is not None:
+                    temperatures.append(group.current_temperature)
+
+        if not temperatures:
+            return None
+        return sum(temperatures) / len(temperatures)
+
+    @property
+    def min_temp(self) -> float:
+        """Return the minimum target temperature the entity should expose."""
+        config_minimums = [
+            value
+            for value in [self.coordinator.config.frost_protection_min_temp]
+            + [zone.frost_protection_min_temp for zone in self.coordinator.config.zones]
+            if value is not None
+        ]
+        return min(config_minimums, default=5.0)
+
+    @property
+    def max_temp(self) -> float:
+        """Return the maximum supported target temperature."""
+        return 35.0
+
+    @property
+    def extra_state_attributes(self) -> dict[str, Any]:
+        """Return system override and demand attributes."""
+        data = self.coordinator.data
+        if data is None:
+            return {}
+
+        override_target_temperature = None
+        override_active = False
+        if data.global_override is not None:
+            override_active = data.global_override.active
+            override_target_temperature = data.global_override.target_temperature
+
+        return {
+            "override_active": override_active,
+            "override_target_temperature": override_target_temperature,
+            "zones_calling_for_heat": [
+                evaluation.name for evaluation in data.zone_evaluations if evaluation.demand
+            ],
+            "global_force_off": data.global_force_off,
+        }
+
+    async def async_set_hvac_mode(self, hvac_mode: HVACMode) -> None:
+        """Set system HVAC mode."""
+        await self.coordinator.async_set_global_force_off(hvac_mode == HVACMode.OFF)
+
+    async def async_set_temperature(self, **kwargs: Any) -> None:
+        """Set the global override target temperature."""
+        target_temperature = kwargs.get("temperature")
+        if target_temperature is None:
+            return
+
+        await self.coordinator.async_set_global_override(float(target_temperature))

--- a/custom_components/multi_zone_heating/climate.py
+++ b/custom_components/multi_zone_heating/climate.py
@@ -11,6 +11,7 @@ from homeassistant.components.climate import (
     HVACMode,
 )
 from homeassistant.const import UnitOfTemperature
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
@@ -19,7 +20,7 @@ from .const import DOMAIN
 
 
 async def async_setup_entry(
-    hass,
+    hass: HomeAssistant,
     entry: MultiZoneHeatingConfigEntry,
     async_add_entities: AddEntitiesCallback,
 ) -> None:
@@ -110,12 +111,14 @@ class MultiZoneHeatingSystemClimate(CoordinatorEntity, ClimateEntity):
     @property
     def min_temp(self) -> float:
         """Return the minimum target temperature the entity should expose."""
-        config_minimums = [
-            value
-            for value in [self.coordinator.config.frost_protection_min_temp]
-            + [zone.frost_protection_min_temp for zone in self.coordinator.config.zones]
-            if value is not None
-        ]
+        config_minimums = []
+        if self.coordinator.config.frost_protection_min_temp is not None:
+            config_minimums.append(self.coordinator.config.frost_protection_min_temp)
+        config_minimums.extend(
+            zone.frost_protection_min_temp
+            for zone in self.coordinator.config.zones
+            if zone.frost_protection_min_temp is not None
+        )
         return min(config_minimums, default=5.0)
 
     @property

--- a/custom_components/multi_zone_heating/climate.py
+++ b/custom_components/multi_zone_heating/climate.py
@@ -82,11 +82,8 @@ class MultiZoneHeatingSystemClimate(CoordinatorEntity, ClimateEntity):
         data = self.coordinator.data
         if data is None:
             return None
-        if data.global_override is not None and data.global_override.active:
+        if data.global_override is not None:
             return data.global_override.target_temperature
-        for target_temperature in data.target_temperatures.values():
-            if target_temperature is not None:
-                return target_temperature
         return None
 
     @property

--- a/custom_components/multi_zone_heating/coordinator.py
+++ b/custom_components/multi_zone_heating/coordinator.py
@@ -34,6 +34,7 @@ from .control_logic import (
 from .models import (
     AggregationMode,
     ControlType,
+    GlobalOverride,
     IntegrationConfig,
     LocalControlGroup,
     NumberSemanticType,
@@ -144,6 +145,8 @@ class MultiZoneHeatingCoordinator(DataUpdateCoordinator[RuntimeSnapshot]):
         self._last_commanded_climate_targets: dict[str, float] = {}
         self._last_commanded_climate_hvac_modes: dict[str, HVACMode] = {}
         self._relay_runtime_state = RelayRuntimeState(is_on=False)
+        self._global_override: GlobalOverride | None = None
+        self._global_force_off = False
 
     async def async_start(self) -> None:
         """Subscribe to state changes and run the initial evaluation."""
@@ -170,14 +173,54 @@ class MultiZoneHeatingCoordinator(DataUpdateCoordinator[RuntimeSnapshot]):
         self._cancel_recheck()
 
     @callback
-    def _async_handle_relevant_state_change(self, _event: Event[Any]) -> None:
+    def _async_handle_relevant_state_change(self, event: Event[Any]) -> None:
         """Reevaluate the system when a relevant entity changes."""
-        self.hass.async_create_task(self.async_request_refresh())
+        self._clear_override_on_target_change(event)
+        self.hass.async_create_task(self.async_refresh())
+
+    async def async_set_zone_enabled(self, zone_name: str, enabled: bool) -> None:
+        """Enable or disable one configured zone."""
+        zone = self.get_zone_config(zone_name)
+        if zone is None or zone.enabled == enabled:
+            return
+
+        zone.enabled = enabled
+        await self.async_refresh()
+
+    async def async_set_global_force_off(self, enabled: bool) -> None:
+        """Enable or disable global force-off."""
+        if self._global_force_off == enabled:
+            return
+
+        self._global_force_off = enabled
+        await self.async_refresh()
+
+    async def async_set_global_override(self, target_temperature: float) -> None:
+        """Set the system-wide override temperature."""
+        self._global_override = GlobalOverride(target_temperature=target_temperature)
+        await self.async_refresh()
+
+    async def async_clear_global_override(self) -> None:
+        """Remove the system-wide override temperature."""
+        if self._global_override is None:
+            return
+
+        self._global_override = None
+        await self.async_refresh()
+
+    def get_zone_config(self, zone_name: str) -> ZoneConfig | None:
+        """Return one configured zone by name."""
+        for zone in self.config.zones:
+            if zone.name == zone_name:
+                return zone
+        return None
 
     async def _async_update_data(self) -> RuntimeSnapshot:
         """Build a snapshot, evaluate demand, and dispatch required commands."""
         now = self._utcnow()
         snapshot = self._build_runtime_snapshot()
+        snapshot.global_override = self._global_override
+        snapshot.global_force_off = self._global_force_off
         flow_value = snapshot.flow_value
 
         previous_relay_is_on = self._relay_runtime_state.is_on
@@ -214,6 +257,7 @@ class MultiZoneHeatingCoordinator(DataUpdateCoordinator[RuntimeSnapshot]):
                 previous_demand=self._last_zone_demands.get(zone.name, False),
                 previous_group_demands=self._last_group_demands.get(zone.name),
                 hysteresis=self.config.default_hysteresis,
+                global_override=self._global_override,
                 global_frost_protection_min_temp=self.config.frost_protection_min_temp,
             )
             zone_evaluations.append(evaluation)
@@ -225,8 +269,9 @@ class MultiZoneHeatingCoordinator(DataUpdateCoordinator[RuntimeSnapshot]):
 
         snapshot.zone_evaluations = zone_evaluations
         snapshot.system_demand = aggregate_system_demand(zone_evaluations)
+        effective_system_demand = snapshot.system_demand and not self._global_force_off
         snapshot.relay_decision = decide_relay_action(
-            system_demand=snapshot.system_demand,
+            system_demand=effective_system_demand,
             relay_state=self._relay_runtime_state,
             now=now,
             min_relay_on_time_seconds=self.config.min_relay_on_time_seconds,
@@ -247,7 +292,7 @@ class MultiZoneHeatingCoordinator(DataUpdateCoordinator[RuntimeSnapshot]):
             off_requested_at=projected_relay_state.off_requested_at,
         )
         flow_warning = evaluate_missing_flow_warning(
-            system_demand=snapshot.system_demand,
+            system_demand=effective_system_demand,
             relay_state=projected_relay_state,
             now=now,
             flow_value=flow_value,
@@ -257,7 +302,10 @@ class MultiZoneHeatingCoordinator(DataUpdateCoordinator[RuntimeSnapshot]):
         snapshot.missing_flow_warning = flow_warning.warning_active
         snapshot.missing_flow_warning_since = flow_warning.warning_since
 
-        await self._async_dispatch_zone_commands(zone_evaluations)
+        await self._async_dispatch_zone_commands(
+            zone_evaluations,
+            force_off=self._global_force_off,
+        )
         await self._async_dispatch_relay_command(snapshot.relay_decision, now)
         self._schedule_recheck(
             _earliest_datetime(
@@ -324,11 +372,55 @@ class MultiZoneHeatingCoordinator(DataUpdateCoordinator[RuntimeSnapshot]):
         snapshot.unavailable_entity_ids = sorted(unavailable_entity_ids)
         return snapshot
 
-    async def _async_dispatch_zone_commands(self, zone_evaluations: list[ZoneEvaluation]) -> None:
+    def _clear_override_on_target_change(self, event: Event[Any]) -> None:
+        """Clear the global override when a zone target changes externally."""
+        if self._global_override is None:
+            return
+
+        entity_id = event.data.get("entity_id")
+        if entity_id is None:
+            return
+
+        zone_target_entity_ids = {zone.target_entity_id for zone in self.config.zones}
+        if entity_id not in zone_target_entity_ids:
+            return
+
+        old_state = event.data.get("old_state")
+        new_state = event.data.get("new_state")
+        if old_state is None or new_state is None:
+            return
+
+        old_temperature = self._extract_target_temperature(entity_id, old_state)
+        new_temperature = self._extract_target_temperature(entity_id, new_state)
+        if old_temperature == new_temperature:
+            return
+
+        self._global_override = None
+
+    def _extract_target_temperature(self, entity_id: str, state: Any) -> float | None:
+        """Read the comparable target value from a target entity state."""
+        if entity_id.split(".", 1)[0] == CLIMATE_DOMAIN:
+            return _as_float(state.attributes.get("temperature"))
+        return _as_float(state.state)
+
+    async def _async_dispatch_zone_commands(
+        self,
+        zone_evaluations: list[ZoneEvaluation],
+        *,
+        force_off: bool,
+    ) -> None:
         """Send zone-level actuator commands when outputs should change."""
         for zone, evaluation in zip(self.config.zones, zone_evaluations, strict=True):
             if zone.control_type is ControlType.CLIMATE:
-                await self._async_dispatch_climate_zone(zone, evaluation)
+                await self._async_dispatch_climate_zone(zone, evaluation, force_off=force_off)
+                continue
+
+            if force_off or not zone.enabled:
+                for group_config in zone.local_groups:
+                    if group_config.control_type is ControlType.SWITCH:
+                        await self._async_dispatch_switch_group(group_config, False)
+                    elif group_config.control_type is ControlType.NUMBER:
+                        await self._async_dispatch_number_group(group_config, False)
                 continue
 
             for group_config, group_evaluation in zip(
@@ -337,14 +429,22 @@ class MultiZoneHeatingCoordinator(DataUpdateCoordinator[RuntimeSnapshot]):
                 strict=True,
             ):
                 if group_config.control_type is ControlType.SWITCH:
-                    await self._async_dispatch_switch_group(group_config, group_evaluation.demand)
+                    await self._async_dispatch_switch_group(
+                        group_config,
+                        group_evaluation.demand and not force_off,
+                    )
                 elif group_config.control_type is ControlType.NUMBER:
-                    await self._async_dispatch_number_group(group_config, group_evaluation.demand)
+                    await self._async_dispatch_number_group(
+                        group_config,
+                        group_evaluation.demand and not force_off,
+                    )
 
     async def _async_dispatch_climate_zone(
         self,
         zone: ZoneConfig,
         evaluation: ZoneEvaluation,
+        *,
+        force_off: bool,
     ) -> None:
         """Synchronize climate actuators with the effective target temperature."""
         for entity_id in zone.climate_entity_ids:
@@ -360,7 +460,7 @@ class MultiZoneHeatingCoordinator(DataUpdateCoordinator[RuntimeSnapshot]):
                 self._clear_climate_hvac_mode_if_synced(entity_id, current_hvac_mode)
 
             hvac_modes = self._read_supported_hvac_modes(entity_id)
-            if evaluation.demand:
+            if evaluation.demand and not force_off:
                 if HVACMode.HEAT in hvac_modes and current_hvac_mode == HVACMode.OFF:
                     await self._async_dispatch_climate_hvac_mode(entity_id, HVACMode.HEAT)
 

--- a/custom_components/multi_zone_heating/coordinator.py
+++ b/custom_components/multi_zone_heating/coordinator.py
@@ -176,7 +176,7 @@ class MultiZoneHeatingCoordinator(DataUpdateCoordinator[RuntimeSnapshot]):
     def _async_handle_relevant_state_change(self, event: Event[Any]) -> None:
         """Reevaluate the system when a relevant entity changes."""
         self._clear_override_on_target_change(event)
-        self.hass.async_create_task(self.async_refresh())
+        self.hass.async_create_task(self.async_request_refresh())
 
     async def async_set_zone_enabled(self, zone_name: str, enabled: bool) -> None:
         """Enable or disable one configured zone."""
@@ -431,12 +431,12 @@ class MultiZoneHeatingCoordinator(DataUpdateCoordinator[RuntimeSnapshot]):
                 if group_config.control_type is ControlType.SWITCH:
                     await self._async_dispatch_switch_group(
                         group_config,
-                        group_evaluation.demand and not force_off,
+                        group_evaluation.demand,
                     )
                 elif group_config.control_type is ControlType.NUMBER:
                     await self._async_dispatch_number_group(
                         group_config,
-                        group_evaluation.demand and not force_off,
+                        group_evaluation.demand,
                     )
 
     async def _async_dispatch_climate_zone(

--- a/custom_components/multi_zone_heating/coordinator.py
+++ b/custom_components/multi_zone_heating/coordinator.py
@@ -185,6 +185,7 @@ class MultiZoneHeatingCoordinator(DataUpdateCoordinator[RuntimeSnapshot]):
             return
 
         zone.enabled = enabled
+        self._persist_zone_enabled(zone_name, enabled)
         await self.async_refresh()
 
     async def async_set_global_force_off(self, enabled: bool) -> None:
@@ -197,7 +198,11 @@ class MultiZoneHeatingCoordinator(DataUpdateCoordinator[RuntimeSnapshot]):
 
     async def async_set_global_override(self, target_temperature: float) -> None:
         """Set the system-wide override temperature."""
-        self._global_override = GlobalOverride(target_temperature=target_temperature)
+        if self._global_override is None:
+            self._global_override = GlobalOverride(target_temperature=target_temperature)
+        else:
+            self._global_override.target_temperature = target_temperature
+            self._global_override.active = True
         await self.async_refresh()
 
     async def async_clear_global_override(self) -> None:
@@ -205,7 +210,7 @@ class MultiZoneHeatingCoordinator(DataUpdateCoordinator[RuntimeSnapshot]):
         if self._global_override is None:
             return
 
-        self._global_override = None
+        self._global_override.active = False
         await self.async_refresh()
 
     def get_zone_config(self, zone_name: str) -> ZoneConfig | None:
@@ -374,7 +379,7 @@ class MultiZoneHeatingCoordinator(DataUpdateCoordinator[RuntimeSnapshot]):
 
     def _clear_override_on_target_change(self, event: Event[Any]) -> None:
         """Clear the global override when a zone target changes externally."""
-        if self._global_override is None:
+        if self._global_override is None or not self._global_override.active:
             return
 
         entity_id = event.data.get("entity_id")
@@ -395,7 +400,27 @@ class MultiZoneHeatingCoordinator(DataUpdateCoordinator[RuntimeSnapshot]):
         if old_temperature == new_temperature:
             return
 
-        self._global_override = None
+        self._global_override.active = False
+
+    def _persist_zone_enabled(self, zone_name: str, enabled: bool) -> None:
+        """Persist the zone-enabled flag into the config entry data."""
+        if self.config_entry is None:
+            return
+
+        zones = []
+        for zone_data in self.config_entry.data.get("zones", []):
+            updated_zone_data = dict(zone_data)
+            if updated_zone_data.get("name") == zone_name:
+                updated_zone_data["enabled"] = enabled
+            zones.append(updated_zone_data)
+
+        self.hass.config_entries.async_update_entry(
+            self.config_entry,
+            data={
+                **self.config_entry.data,
+                "zones": zones,
+            },
+        )
 
     def _extract_target_temperature(self, entity_id: str, state: Any) -> float | None:
         """Read the comparable target value from a target entity state."""

--- a/custom_components/multi_zone_heating/models.py
+++ b/custom_components/multi_zone_heating/models.py
@@ -96,6 +96,7 @@ class RuntimeData:
     """Runtime container attached to the config entry."""
 
     config_entry_id: str
+    title: str = ""
     config: IntegrationConfig = field(default_factory=IntegrationConfig)
     coordinator: MultiZoneHeatingCoordinator | None = None
 
@@ -179,6 +180,8 @@ class RuntimeSnapshot:
 
     sensor_values: dict[str, float | None] = field(default_factory=dict)
     target_temperatures: dict[str, float | None] = field(default_factory=dict)
+    global_override: GlobalOverride | None = None
+    global_force_off: bool = False
     flow_value: float | None = None
     flow_detected: bool = False
     missing_flow_warning: bool = False

--- a/custom_components/multi_zone_heating/sensor.py
+++ b/custom_components/multi_zone_heating/sensor.py
@@ -2,17 +2,86 @@
 
 from __future__ import annotations
 
-from collections.abc import Callable
 from typing import Any
 
-from homeassistant.core import HomeAssistant
+from homeassistant.components.sensor import SensorEntity
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from . import MultiZoneHeatingConfigEntry
+from .const import DOMAIN
 
 
 async def async_setup_entry(
-    hass: HomeAssistant,
+    hass,
     entry: MultiZoneHeatingConfigEntry,
-    async_add_entities: Callable[[list[Any]], None],
+    async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up sensors for a config entry."""
+    if entry.runtime_data.coordinator is None:
+        return
+    async_add_entities([MultiZoneHeatingRelayStateSensor(entry)])
+
+
+class MultiZoneHeatingRelayStateSensor(CoordinatorEntity, SensorEntity):
+    """Diagnostic sensor describing relay control state."""
+
+    _attr_has_entity_name = True
+
+    def __init__(self, entry: MultiZoneHeatingConfigEntry) -> None:
+        """Initialize the entity."""
+        super().__init__(entry.runtime_data.coordinator)
+        self._entry = entry
+        self._attr_name = "Relay State"
+        self._attr_unique_id = f"{entry.entry_id}_relay_state"
+        self._attr_icon = "mdi:valve"
+
+    @property
+    def available(self) -> bool:
+        """Return whether coordinator data is available."""
+        return self.coordinator.data is not None
+
+    @property
+    def device_info(self) -> dict[str, object]:
+        """Describe the integration device that owns these entities."""
+        return {
+            "identifiers": {(DOMAIN, self._entry.entry_id)},
+            "name": self._entry.title,
+        }
+
+    @property
+    def native_value(self) -> str | None:
+        """Return the relay diagnostic state."""
+        data = self.coordinator.data
+        if data is None or data.relay_runtime_state is None:
+            return None
+
+        if data.global_force_off:
+            return "forced_off"
+
+        if data.relay_decision is not None and data.relay_decision.hold_reason == "off_delay":
+            return "pending_off"
+
+        return "on" if data.relay_runtime_state.is_on else "off"
+
+    @property
+    def extra_state_attributes(self) -> dict[str, Any]:
+        """Return relay diagnostics."""
+        data = self.coordinator.data
+        if data is None:
+            return {}
+
+        zones_calling_for_heat = [
+            evaluation.name for evaluation in data.zone_evaluations if evaluation.demand
+        ]
+        return {
+            "desired_on": data.relay_decision.desired_on if data.relay_decision else None,
+            "hold_reason": data.relay_decision.hold_reason if data.relay_decision else None,
+            "missing_flow_warning": data.missing_flow_warning,
+            "missing_flow_warning_since": data.missing_flow_warning_since.isoformat()
+            if data.missing_flow_warning_since is not None
+            else None,
+            "flow_detected": data.flow_detected,
+            "flow_value": data.flow_value,
+            "zones_calling_for_heat": zones_calling_for_heat,
+        }

--- a/custom_components/multi_zone_heating/sensor.py
+++ b/custom_components/multi_zone_heating/sensor.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from typing import Any
 
 from homeassistant.components.sensor import SensorEntity
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
@@ -13,7 +14,7 @@ from .const import DOMAIN
 
 
 async def async_setup_entry(
-    hass,
+    hass: HomeAssistant,
     entry: MultiZoneHeatingConfigEntry,
     async_add_entities: AddEntitiesCallback,
 ) -> None:

--- a/custom_components/multi_zone_heating/services.yaml
+++ b/custom_components/multi_zone_heating/services.yaml
@@ -1,0 +1,3 @@
+clear_override:
+  name: Clear Override
+  description: Clear the active global override target temperature for all loaded multi-zone heating entries.

--- a/custom_components/multi_zone_heating/switch.py
+++ b/custom_components/multi_zone_heating/switch.py
@@ -2,17 +2,107 @@
 
 from __future__ import annotations
 
-from collections.abc import Callable
-from typing import Any
-
-from homeassistant.core import HomeAssistant
+from homeassistant.components.switch import SwitchEntity
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from . import MultiZoneHeatingConfigEntry
+from .const import DOMAIN
 
 
 async def async_setup_entry(
-    hass: HomeAssistant,
+    hass,
     entry: MultiZoneHeatingConfigEntry,
-    async_add_entities: Callable[[list[Any]], None],
+    async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up switches for a config entry."""
+    runtime_data = entry.runtime_data
+    coordinator = runtime_data.coordinator
+    if coordinator is None:
+        return
+
+    entities: list[SwitchEntity] = [
+        MultiZoneHeatingGlobalForceOffSwitch(entry),
+        *[
+            MultiZoneHeatingZoneEnabledSwitch(entry, zone.name)
+            for zone in runtime_data.config.zones
+        ],
+    ]
+    async_add_entities(entities)
+
+
+class MultiZoneHeatingSwitchBase(CoordinatorEntity, SwitchEntity):
+    """Base switch entity backed by the runtime coordinator."""
+
+    _attr_has_entity_name = True
+
+    def __init__(self, entry: MultiZoneHeatingConfigEntry) -> None:
+        """Initialize the entity."""
+        super().__init__(entry.runtime_data.coordinator)
+        self._entry = entry
+
+    @property
+    def available(self) -> bool:
+        """Return whether coordinator data is available."""
+        return self.coordinator.data is not None
+
+    @property
+    def device_info(self) -> dict[str, object]:
+        """Describe the integration device that owns these entities."""
+        return {
+            "identifiers": {(DOMAIN, self._entry.entry_id)},
+            "name": self._entry.title,
+        }
+
+
+class MultiZoneHeatingGlobalForceOffSwitch(MultiZoneHeatingSwitchBase):
+    """Switch controlling the global force-off mode."""
+
+    def __init__(self, entry: MultiZoneHeatingConfigEntry) -> None:
+        """Initialize the entity."""
+        super().__init__(entry)
+        self._attr_name = "Global Force Off"
+        self._attr_unique_id = f"{entry.entry_id}_global_force_off"
+        self._attr_icon = "mdi:power"
+
+    @property
+    def is_on(self) -> bool | None:
+        """Return whether global force-off is active."""
+        if self.coordinator.data is None:
+            return None
+        return self.coordinator.data.global_force_off
+
+    async def async_turn_on(self, **kwargs) -> None:
+        """Enable global force-off."""
+        await self.coordinator.async_set_global_force_off(True)
+
+    async def async_turn_off(self, **kwargs) -> None:
+        """Disable global force-off."""
+        await self.coordinator.async_set_global_force_off(False)
+
+
+class MultiZoneHeatingZoneEnabledSwitch(MultiZoneHeatingSwitchBase):
+    """Switch controlling whether one zone may call for heat."""
+
+    def __init__(self, entry: MultiZoneHeatingConfigEntry, zone_name: str) -> None:
+        """Initialize the entity."""
+        super().__init__(entry)
+        self._zone_name = zone_name
+        self._attr_name = f"{zone_name} Enabled"
+        self._attr_unique_id = f"{entry.entry_id}_{zone_name}_enabled"
+
+    @property
+    def is_on(self) -> bool | None:
+        """Return whether the configured zone is enabled."""
+        zone = self.coordinator.get_zone_config(self._zone_name)
+        if zone is None:
+            return None
+        return zone.enabled
+
+    async def async_turn_on(self, **kwargs) -> None:
+        """Enable the zone."""
+        await self.coordinator.async_set_zone_enabled(self._zone_name, True)
+
+    async def async_turn_off(self, **kwargs) -> None:
+        """Disable the zone."""
+        await self.coordinator.async_set_zone_enabled(self._zone_name, False)

--- a/custom_components/multi_zone_heating/switch.py
+++ b/custom_components/multi_zone_heating/switch.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from homeassistant.components.switch import SwitchEntity
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
@@ -11,7 +12,7 @@ from .const import DOMAIN
 
 
 async def async_setup_entry(
-    hass,
+    hass: HomeAssistant,
     entry: MultiZoneHeatingConfigEntry,
     async_add_entities: AddEntitiesCallback,
 ) -> None:

--- a/tests/components/multi_zone_heating/test_entities.py
+++ b/tests/components/multi_zone_heating/test_entities.py
@@ -1,0 +1,167 @@
+"""Tests for multi_zone_heating entities and override behavior."""
+
+from __future__ import annotations
+
+from homeassistant.const import ATTR_ENTITY_ID, STATE_OFF, STATE_ON
+from homeassistant.core import ServiceCall
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from custom_components.multi_zone_heating.const import DOMAIN
+
+
+def _build_config_entry() -> MockConfigEntry:
+    """Create a config entry with one switch-controlled zone."""
+    return MockConfigEntry(
+        domain=DOMAIN,
+        title="Multi-Zone Heating",
+        data={
+            "main_relay_entity_id": "switch.boiler",
+            "default_hysteresis": 0.3,
+            "relay_off_delay_seconds": 0,
+            "zones": [
+                {
+                    "name": "Living Room",
+                    "enabled": True,
+                    "control_type": "switch",
+                    "target_source": "input_number",
+                    "target_entity_id": "input_number.living_room_target",
+                    "local_groups": [
+                        {
+                            "name": "Radiator",
+                            "control_type": "switch",
+                            "actuator_entity_ids": ["switch.radiator"],
+                            "sensor_entity_ids": ["sensor.living_room_temperature"],
+                            "aggregation_mode": "average",
+                        }
+                    ],
+                }
+            ],
+        },
+        version=1,
+    )
+
+
+def _register_recording_switch_services(hass) -> list[tuple[str, dict[str, str]]]:
+    """Register fake switch services and record each invocation."""
+    calls: list[tuple[str, dict[str, str]]] = []
+
+    async def _record_turn_on(call: ServiceCall) -> None:
+        calls.append(("turn_on", dict(call.data)))
+        hass.states.async_set(call.data[ATTR_ENTITY_ID], STATE_ON)
+
+    async def _record_turn_off(call: ServiceCall) -> None:
+        calls.append(("turn_off", dict(call.data)))
+        hass.states.async_set(call.data[ATTR_ENTITY_ID], STATE_OFF)
+
+    hass.services.async_register("switch", "turn_on", _record_turn_on)
+    hass.services.async_register("switch", "turn_off", _record_turn_off)
+    return calls
+
+
+async def _setup_loaded_entry(hass) -> tuple[MockConfigEntry, list[tuple[str, dict[str, str]]]]:
+    """Set up a config entry with states and switch service mocks."""
+    hass.states.async_set("sensor.living_room_temperature", "19.0")
+    hass.states.async_set("input_number.living_room_target", "20.0")
+    hass.states.async_set("switch.radiator", STATE_OFF)
+    hass.states.async_set("switch.boiler", STATE_OFF)
+
+    calls = _register_recording_switch_services(hass)
+    entry = _build_config_entry()
+    entry.add_to_hass(hass)
+    assert await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+    return entry, calls
+
+
+async def test_system_climate_sets_and_clears_override(hass) -> None:
+    """The top-level climate entity should manage the global override."""
+    await _setup_loaded_entry(hass)
+
+    climate_state = hass.states.get("climate.multi_zone_heating_system")
+    assert climate_state is not None
+    assert climate_state.state == "heat"
+    assert climate_state.attributes["override_active"] is False
+
+    await hass.services.async_call(
+        "climate",
+        "set_temperature",
+        {
+            ATTR_ENTITY_ID: "climate.multi_zone_heating_system",
+            "temperature": 21.5,
+        },
+        blocking=True,
+    )
+    await hass.async_block_till_done()
+
+    climate_state = hass.states.get("climate.multi_zone_heating_system")
+    assert climate_state is not None
+    assert climate_state.attributes["override_active"] is True
+    assert climate_state.attributes["override_target_temperature"] == 21.5
+
+    await hass.services.async_call(DOMAIN, "clear_override", {}, blocking=True)
+    await hass.async_block_till_done()
+
+    climate_state = hass.states.get("climate.multi_zone_heating_system")
+    assert climate_state is not None
+    assert climate_state.attributes["override_active"] is False
+    assert climate_state.attributes["override_target_temperature"] is None
+
+
+async def test_zone_target_change_clears_override(hass) -> None:
+    """Changing a zone target should end the global override."""
+    await _setup_loaded_entry(hass)
+
+    await hass.services.async_call(
+        "climate",
+        "set_temperature",
+        {
+            ATTR_ENTITY_ID: "climate.multi_zone_heating_system",
+            "temperature": 21.5,
+        },
+        blocking=True,
+    )
+    await hass.async_block_till_done()
+
+    hass.states.async_set("input_number.living_room_target", "19.0")
+    await hass.async_block_till_done()
+
+    climate_state = hass.states.get("climate.multi_zone_heating_system")
+    assert climate_state is not None
+    assert climate_state.attributes["override_active"] is False
+    assert climate_state.attributes["override_target_temperature"] is None
+
+
+async def test_zone_enable_and_global_force_off_switches_control_runtime(hass) -> None:
+    """Entity switches should disable zones and force outputs off."""
+    await _setup_loaded_entry(hass)
+
+    await hass.services.async_call(
+        "switch",
+        "turn_off",
+        {"entity_id": "switch.multi_zone_heating_living_room_enabled"},
+        blocking=True,
+    )
+    await hass.async_block_till_done()
+
+    zone_state = hass.states.get("binary_sensor.multi_zone_heating_living_room_demand")
+    system_state = hass.states.get("binary_sensor.multi_zone_heating_system_demand")
+    assert zone_state is not None
+    assert zone_state.state == STATE_OFF
+    assert system_state is not None
+    assert system_state.state == STATE_OFF
+
+    await hass.services.async_call(
+        "switch",
+        "turn_on",
+        {"entity_id": "switch.multi_zone_heating_global_force_off"},
+        blocking=True,
+    )
+    await hass.async_block_till_done()
+
+    climate_state = hass.states.get("climate.multi_zone_heating_system")
+    relay_state = hass.states.get("sensor.multi_zone_heating_relay_state")
+    assert climate_state is not None
+    assert climate_state.state == "off"
+    assert climate_state.attributes["global_force_off"] is True
+    assert relay_state is not None
+    assert relay_state.state == "forced_off"

--- a/tests/components/multi_zone_heating/test_entities.py
+++ b/tests/components/multi_zone_heating/test_entities.py
@@ -104,7 +104,7 @@ async def test_system_climate_sets_and_clears_override(hass) -> None:
     climate_state = hass.states.get("climate.multi_zone_heating_system")
     assert climate_state is not None
     assert climate_state.attributes["override_active"] is False
-    assert climate_state.attributes["override_target_temperature"] is None
+    assert climate_state.attributes["override_target_temperature"] == 21.5
 
 
 async def test_zone_target_change_clears_override(hass) -> None:
@@ -128,12 +128,12 @@ async def test_zone_target_change_clears_override(hass) -> None:
     climate_state = hass.states.get("climate.multi_zone_heating_system")
     assert climate_state is not None
     assert climate_state.attributes["override_active"] is False
-    assert climate_state.attributes["override_target_temperature"] is None
+    assert climate_state.attributes["override_target_temperature"] == 21.5
 
 
 async def test_zone_enable_and_global_force_off_switches_control_runtime(hass) -> None:
     """Entity switches should disable zones and force outputs off."""
-    await _setup_loaded_entry(hass)
+    entry, _ = await _setup_loaded_entry(hass)
 
     await hass.services.async_call(
         "switch",
@@ -149,6 +149,7 @@ async def test_zone_enable_and_global_force_off_switches_control_runtime(hass) -
     assert zone_state.state == STATE_OFF
     assert system_state is not None
     assert system_state.state == STATE_OFF
+    assert entry.data["zones"][0]["enabled"] is False
 
     await hass.services.async_call(
         "switch",
@@ -165,3 +166,26 @@ async def test_zone_enable_and_global_force_off_switches_control_runtime(hass) -
     assert climate_state.attributes["global_force_off"] is True
     assert relay_state is not None
     assert relay_state.state == "forced_off"
+
+
+async def test_zone_enable_toggle_persists_in_config_entry(hass) -> None:
+    """Zone enable changes should update the config entry data."""
+    entry, _ = await _setup_loaded_entry(hass)
+
+    await hass.services.async_call(
+        "switch",
+        "turn_off",
+        {"entity_id": "switch.multi_zone_heating_living_room_enabled"},
+        blocking=True,
+    )
+    await hass.async_block_till_done()
+    assert entry.data["zones"][0]["enabled"] is False
+
+    await hass.services.async_call(
+        "switch",
+        "turn_on",
+        {"entity_id": "switch.multi_zone_heating_living_room_enabled"},
+        blocking=True,
+    )
+    await hass.async_block_till_done()
+    assert entry.data["zones"][0]["enabled"] is True


### PR DESCRIPTION
## Summary
- implement the Home Assistant entity surface for multi-zone heating
- add runtime global override and global force-off behavior in the coordinator
- expose a top-level system climate entity, zone/system demand sensors, relay diagnostics, and zone/global switches
- register a `clear_override` service and cover the new behavior with integration tests

## Validation
- `PYTHONPATH=. .venv/bin/pytest -q`

Closes #11 