### PR TITLE
[codex] Implement options flow editing

### DIFF
--- a/custom_components/multi_zone_heating/__init__.py
+++ b/custom_components/multi_zone_heating/__init__.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from copy import deepcopy
 from typing import TYPE_CHECKING, TypeAlias
 
 from homeassistant.config_entries import ConfigEntry
@@ -24,7 +25,11 @@ async def async_setup_entry(
 ) -> bool:
     """Set up multi_zone_heating from a config entry."""
     domain_data: dict[str, RuntimeData] = hass.data.setdefault(DOMAIN, {})
-    config = integration_config_from_dict(entry.data)
+    entry.async_on_unload(entry.add_update_listener(_async_update_listener))
+
+    merged_config = deepcopy(dict(entry.data))
+    merged_config.update(deepcopy(dict(entry.options)))
+    config = integration_config_from_dict(merged_config)
     coordinator = MultiZoneHeatingCoordinator(hass, config, config_entry=entry)
     entry.runtime_data = RuntimeData(
         config_entry_id=entry.entry_id,
@@ -72,3 +77,11 @@ async def _async_clear_overrides(hass: HomeAssistant) -> None:
     for runtime_data in hass.data.get(DOMAIN, {}).values():
         if runtime_data.coordinator is not None:
             await runtime_data.coordinator.async_clear_global_override()
+
+
+async def _async_update_listener(
+    hass: HomeAssistant,
+    entry: MultiZoneHeatingConfigEntry,
+) -> None:
+    """Reload the entry when options change so runtime state stays in sync."""
+    await hass.config_entries.async_reload(entry.entry_id)

--- a/custom_components/multi_zone_heating/__init__.py
+++ b/custom_components/multi_zone_heating/__init__.py
@@ -71,14 +71,11 @@ async def async_unload_entry(
             hass.services.async_remove(DOMAIN, "clear_override")
     return unloaded
 
-
 async def _async_clear_overrides(hass: HomeAssistant) -> None:
     """Clear runtime overrides for all loaded entries."""
     for runtime_data in hass.data.get(DOMAIN, {}).values():
         if runtime_data.coordinator is not None:
             await runtime_data.coordinator.async_clear_global_override()
-
-
 async def _async_update_listener(
     hass: HomeAssistant,
     entry: MultiZoneHeatingConfigEntry,

--- a/custom_components/multi_zone_heating/config_flow.py
+++ b/custom_components/multi_zone_heating/config_flow.py
@@ -932,13 +932,15 @@ class MultiZoneHeatingOptionsFlow(
                 self._clear_pending_zone()
                 return await self.async_step_init()
 
-        actions = [{"value": ACTION_ADD_GROUP, "label": "Add local group"}]
+        actions = [
+            {"value": ACTION_ADD_GROUP, "label": "Add local group"},
+            {"value": ACTION_DONE, "label": "Done with zone"},
+        ]
         if self._pending_local_groups:
             actions.extend(
                 [
                     {"value": ACTION_EDIT_GROUP, "label": "Edit local group"},
                     {"value": ACTION_REMOVE_GROUP, "label": "Remove local group"},
-                    {"value": ACTION_DONE, "label": "Done with zone"},
                 ]
             )
 

--- a/custom_components/multi_zone_heating/config_flow.py
+++ b/custom_components/multi_zone_heating/config_flow.py
@@ -1,16 +1,20 @@
-"""Config flow for the multi_zone_heating integration."""
+"""Config and options flow for the multi_zone_heating integration."""
 
 from __future__ import annotations
 
+from copy import deepcopy
+
 import voluptuous as vol
 
-from homeassistant.config_entries import ConfigFlow
+from homeassistant.config_entries import ConfigEntry, ConfigFlow, OptionsFlowWithConfigEntry
 from homeassistant.const import CONF_NAME
+from homeassistant.core import callback
 from homeassistant.helpers import selector
 
 from .const import DEFAULT_TITLE, DOMAIN
 from .models import AggregationMode, ControlType, NumberSemanticType, TargetSourceType
 
+CONF_ACTION = "action"
 CONF_ACTIVE_VALUE = "active_value"
 CONF_ACTUATOR_ENTITY_IDS = "actuator_entity_ids"
 CONF_AGGREGATION_MODE = "aggregation_mode"
@@ -22,6 +26,7 @@ CONF_ENABLED = "enabled"
 CONF_FLOW_DETECTION_THRESHOLD = "flow_detection_threshold"
 CONF_FLOW_SENSOR_ENTITY_ID = "flow_sensor_entity_id"
 CONF_FROST_PROTECTION_MIN_TEMP = "frost_protection_min_temp"
+CONF_GROUP = "group"
 CONF_INACTIVE_VALUE = "inactive_value"
 CONF_LOCAL_GROUPS = "local_groups"
 CONF_MAIN_RELAY_ENTITY_ID = "main_relay_entity_id"
@@ -34,7 +39,17 @@ CONF_RELAY_OFF_DELAY_SECONDS = "relay_off_delay_seconds"
 CONF_SENSOR_ENTITY_IDS = "sensor_entity_ids"
 CONF_TARGET_ENTITY_ID = "target_entity_id"
 CONF_TARGET_SOURCE = "target_source"
+CONF_ZONE = "zone"
 CONF_ZONES = "zones"
+
+ACTION_ADD_GROUP = "add_group"
+ACTION_ADD_ZONE = "add_zone"
+ACTION_DONE = "done"
+ACTION_EDIT_GLOBALS = "edit_globals"
+ACTION_EDIT_GROUP = "edit_group"
+ACTION_EDIT_ZONE = "edit_zone"
+ACTION_REMOVE_GROUP = "remove_group"
+ACTION_REMOVE_ZONE = "remove_zone"
 
 DEFAULT_HYSTERESIS = 0.3
 DEFAULT_MISSING_FLOW_TIMEOUT_SECONDS = 60
@@ -43,202 +58,17 @@ DEFAULT_MIN_RELAY_OFF_TIME_SECONDS = 0
 DEFAULT_RELAY_OFF_DELAY_SECONDS = 0
 
 
-class MultiZoneHeatingConfigFlow(ConfigFlow, domain=DOMAIN):
-    """Config flow for setting up a multi-zone heating system."""
-
-    VERSION = 1
+class _MultiZoneHeatingFlowBase:
+    """Shared helpers for config and options flows."""
 
     def __init__(self) -> None:
-        """Initialize the config flow."""
+        """Initialize shared flow state."""
         self._config: dict[str, object] = {}
         self._title = DEFAULT_TITLE
         self._pending_zone: dict[str, object] | None = None
         self._pending_local_groups: list[dict[str, object]] = []
-
-    async def async_step_user(
-        self,
-        user_input: dict[str, object] | None = None,
-    ):
-        """Handle the initial global system setup step."""
-        errors: dict[str, str] = {}
-
-        if user_input is not None:
-            errors = self._validate_global_config(user_input)
-            if not errors:
-                await self.async_set_unique_id(DOMAIN)
-                self._abort_if_unique_id_configured()
-
-                self._title = str(user_input.get(CONF_NAME, DEFAULT_TITLE)).strip() or DEFAULT_TITLE
-                self._config = {
-                    CONF_MAIN_RELAY_ENTITY_ID: user_input[CONF_MAIN_RELAY_ENTITY_ID],
-                    CONF_FLOW_SENSOR_ENTITY_ID: user_input.get(CONF_FLOW_SENSOR_ENTITY_ID),
-                    CONF_FLOW_DETECTION_THRESHOLD: user_input.get(CONF_FLOW_DETECTION_THRESHOLD),
-                    CONF_MISSING_FLOW_TIMEOUT_SECONDS: int(
-                        user_input[CONF_MISSING_FLOW_TIMEOUT_SECONDS]
-                    ),
-                    CONF_DEFAULT_HYSTERESIS: user_input[CONF_DEFAULT_HYSTERESIS],
-                    CONF_MIN_RELAY_ON_TIME_SECONDS: int(user_input[CONF_MIN_RELAY_ON_TIME_SECONDS]),
-                    CONF_MIN_RELAY_OFF_TIME_SECONDS: int(user_input[CONF_MIN_RELAY_OFF_TIME_SECONDS]),
-                    CONF_RELAY_OFF_DELAY_SECONDS: int(user_input[CONF_RELAY_OFF_DELAY_SECONDS]),
-                    CONF_FROST_PROTECTION_MIN_TEMP: user_input.get(CONF_FROST_PROTECTION_MIN_TEMP),
-                    CONF_ZONES: [],
-                }
-                return await self.async_step_zone()
-
-        data_schema = self._global_schema(user_input)
-        return self.async_show_form(
-            step_id="user",
-            data_schema=data_schema,
-            errors=errors,
-        )
-
-    async def async_step_zone(
-        self,
-        user_input: dict[str, object] | None = None,
-    ):
-        """Collect the shared configuration for a zone."""
-        errors: dict[str, str] = {}
-
-        if user_input is not None:
-            errors = self._validate_zone_basics(user_input)
-            if not errors:
-                self._pending_zone = {
-                    CONF_NAME: user_input[CONF_NAME],
-                    CONF_ENABLED: user_input[CONF_ENABLED],
-                    CONF_CONTROL_TYPE: user_input[CONF_CONTROL_TYPE],
-                    CONF_TARGET_SOURCE: user_input[CONF_TARGET_SOURCE],
-                    CONF_TARGET_ENTITY_ID: user_input[CONF_TARGET_ENTITY_ID],
-                    CONF_FROST_PROTECTION_MIN_TEMP: user_input.get(
-                        CONF_FROST_PROTECTION_MIN_TEMP
-                    ),
-                }
-                self._pending_local_groups = []
-
-                if user_input[CONF_CONTROL_TYPE] == ControlType.CLIMATE:
-                    return await self.async_step_climate_zone()
-
-                return await self.async_step_local_group()
-
-        return self.async_show_form(
-            step_id="zone",
-            data_schema=self._zone_basics_schema(user_input),
-            errors=errors,
-        )
-
-    async def async_step_climate_zone(
-        self,
-        user_input: dict[str, object] | None = None,
-    ):
-        """Collect climate-zone-specific settings."""
-        errors: dict[str, str] = {}
-
-        if user_input is not None:
-            errors = self._validate_climate_zone_details(user_input)
-            if not errors and self._pending_zone is not None:
-                zone = {
-                    **self._pending_zone,
-                    CONF_SENSOR_ENTITY_IDS: user_input[CONF_SENSOR_ENTITY_IDS],
-                    CONF_CLIMATE_ENTITY_IDS: user_input[CONF_CLIMATE_ENTITY_IDS],
-                    CONF_CLIMATE_OFF_FALLBACK_TEMPERATURE: user_input.get(
-                        CONF_CLIMATE_OFF_FALLBACK_TEMPERATURE
-                    ),
-                    CONF_LOCAL_GROUPS: [],
-                    CONF_AGGREGATION_MODE: user_input[CONF_AGGREGATION_MODE],
-                    CONF_PRIMARY_SENSOR_ENTITY_ID: user_input.get(
-                        CONF_PRIMARY_SENSOR_ENTITY_ID
-                    ),
-                }
-                self._add_zone(zone)
-                self._pending_zone = None
-                return await self.async_step_zone_options()
-
-        return self.async_show_form(
-            step_id="climate_zone",
-            data_schema=self._climate_zone_schema(user_input),
-            errors=errors,
-        )
-
-    async def async_step_local_group(
-        self,
-        user_input: dict[str, object] | None = None,
-    ):
-        """Collect one local control group for a switch or number zone."""
-        errors: dict[str, str] = {}
-        zone_control_type = self._pending_zone_control_type()
-
-        if zone_control_type is None:
-            return await self.async_step_zone()
-
-        if user_input is not None:
-            errors = self._validate_local_group(user_input, zone_control_type)
-            if not errors:
-                group = {
-                    CONF_NAME: user_input[CONF_NAME],
-                    CONF_CONTROL_TYPE: zone_control_type,
-                    CONF_SENSOR_ENTITY_IDS: user_input[CONF_SENSOR_ENTITY_IDS],
-                    CONF_ACTUATOR_ENTITY_IDS: user_input[CONF_ACTUATOR_ENTITY_IDS],
-                    CONF_AGGREGATION_MODE: user_input[CONF_AGGREGATION_MODE],
-                    CONF_PRIMARY_SENSOR_ENTITY_ID: user_input.get(
-                        CONF_PRIMARY_SENSOR_ENTITY_ID
-                    ),
-                    CONF_NUMBER_SEMANTIC_TYPE: user_input.get(CONF_NUMBER_SEMANTIC_TYPE),
-                    CONF_ACTIVE_VALUE: user_input.get(CONF_ACTIVE_VALUE),
-                    CONF_INACTIVE_VALUE: user_input.get(CONF_INACTIVE_VALUE),
-                }
-                self._pending_local_groups.append(group)
-                return await self.async_step_local_group_options()
-
-        return self.async_show_form(
-            step_id="local_group",
-            data_schema=self._local_group_schema(zone_control_type, user_input),
-            errors=errors,
-        )
-
-    async def async_step_local_group_options(
-        self,
-        user_input: dict[str, object] | None = None,
-    ):
-        """Decide whether to add more local control groups."""
-        if self._pending_zone is None:
-            return await self.async_step_zone()
-
-        if user_input is not None:
-            if user_input["add_another_group"]:
-                return await self.async_step_local_group()
-
-            zone = {
-                **self._pending_zone,
-                CONF_SENSOR_ENTITY_IDS: [],
-                CONF_CLIMATE_ENTITY_IDS: [],
-                CONF_LOCAL_GROUPS: self._pending_local_groups,
-                CONF_AGGREGATION_MODE: AggregationMode.AVERAGE,
-                CONF_PRIMARY_SENSOR_ENTITY_ID: None,
-            }
-            self._add_zone(zone)
-            self._pending_zone = None
-            self._pending_local_groups = []
-            return await self.async_step_zone_options()
-
-        return self.async_show_form(
-            step_id="local_group_options",
-            data_schema=self._local_group_options_schema(),
-        )
-
-    async def async_step_zone_options(
-        self,
-        user_input: dict[str, object] | None = None,
-    ):
-        """Decide whether to add another zone or finish setup."""
-        if user_input is not None:
-            if user_input["add_another_zone"]:
-                return await self.async_step_zone()
-
-            return self.async_create_entry(title=self._title, data=self._config)
-
-        return self.async_show_form(
-            step_id="zone_options",
-            data_schema=self._zone_options_schema(),
-        )
+        self._editing_zone_index: int | None = None
+        self._editing_local_group_index: int | None = None
 
     def _global_schema(
         self, user_input: dict[str, object] | None = None
@@ -443,6 +273,54 @@ class MultiZoneHeatingConfigFlow(ConfigFlow, domain=DOMAIN):
             }
         )
 
+    def _action_schema(self, options: list[dict[str, str]]) -> vol.Schema:
+        """Build a select-based action schema."""
+        return vol.Schema(
+            {
+                vol.Required(CONF_ACTION): selector.SelectSelector(
+                    selector.SelectSelectorConfig(options=options, mode="dropdown")
+                )
+            }
+        )
+
+    def _zone_select_schema(self, zones: list[dict[str, object]]) -> vol.Schema:
+        """Build a zone-selection schema."""
+        return vol.Schema(
+            {
+                vol.Required(CONF_ZONE): selector.SelectSelector(
+                    selector.SelectSelectorConfig(
+                        options=[
+                            {
+                                "value": str(index),
+                                "label": self._zone_label(zone),
+                            }
+                            for index, zone in enumerate(zones)
+                        ],
+                        mode="dropdown",
+                    )
+                )
+            }
+        )
+
+    def _group_select_schema(self, groups: list[dict[str, object]]) -> vol.Schema:
+        """Build a local-group selection schema."""
+        return vol.Schema(
+            {
+                vol.Required(CONF_GROUP): selector.SelectSelector(
+                    selector.SelectSelectorConfig(
+                        options=[
+                            {
+                                "value": str(index),
+                                "label": self._group_label(group),
+                            }
+                            for index, group in enumerate(groups)
+                        ],
+                        mode="dropdown",
+                    )
+                )
+            }
+        )
+
     def _validate_global_config(self, user_input: dict[str, object]) -> dict[str, str]:
         """Validate global configuration values."""
         if (
@@ -511,9 +389,6 @@ class MultiZoneHeatingConfigFlow(ConfigFlow, domain=DOMAIN):
                 return {"base": "primary_sensor_required"}
             if primary_sensor not in user_input[CONF_SENSOR_ENTITY_IDS]:
                 return {"base": "primary_sensor_not_in_sensors"}
-        # Number-based groups always require both configured values in v1 so the
-        # later runtime logic can deterministically drive the actuator when heat
-        # starts and when it stops, regardless of semantic type.
         if zone_control_type == ControlType.NUMBER and (
             user_input.get(CONF_ACTIVE_VALUE) is None
             or user_input.get(CONF_INACTIVE_VALUE) is None
@@ -521,11 +396,86 @@ class MultiZoneHeatingConfigFlow(ConfigFlow, domain=DOMAIN):
             return {"base": "number_values_required"}
         return {}
 
+    def _save_global_config(self, user_input: dict[str, object]) -> None:
+        """Store global configuration values in the working config."""
+        self._title = str(user_input.get(CONF_NAME, DEFAULT_TITLE)).strip() or DEFAULT_TITLE
+        zones = list(self._config.get(CONF_ZONES, []))
+        self._config = {
+            CONF_MAIN_RELAY_ENTITY_ID: user_input[CONF_MAIN_RELAY_ENTITY_ID],
+            CONF_FLOW_SENSOR_ENTITY_ID: user_input.get(CONF_FLOW_SENSOR_ENTITY_ID),
+            CONF_FLOW_DETECTION_THRESHOLD: user_input.get(CONF_FLOW_DETECTION_THRESHOLD),
+            CONF_MISSING_FLOW_TIMEOUT_SECONDS: int(
+                user_input[CONF_MISSING_FLOW_TIMEOUT_SECONDS]
+            ),
+            CONF_DEFAULT_HYSTERESIS: user_input[CONF_DEFAULT_HYSTERESIS],
+            CONF_MIN_RELAY_ON_TIME_SECONDS: int(user_input[CONF_MIN_RELAY_ON_TIME_SECONDS]),
+            CONF_MIN_RELAY_OFF_TIME_SECONDS: int(user_input[CONF_MIN_RELAY_OFF_TIME_SECONDS]),
+            CONF_RELAY_OFF_DELAY_SECONDS: int(user_input[CONF_RELAY_OFF_DELAY_SECONDS]),
+            CONF_FROST_PROTECTION_MIN_TEMP: user_input.get(CONF_FROST_PROTECTION_MIN_TEMP),
+            CONF_ZONES: zones,
+        }
+
     def _pending_zone_control_type(self) -> ControlType | None:
         """Return the control type for the pending zone."""
         if self._pending_zone is None:
             return None
         return ControlType(self._pending_zone[CONF_CONTROL_TYPE])
+
+    def _build_pending_zone(self, user_input: dict[str, object]) -> None:
+        """Store the shared zone fields that apply to all control types."""
+        self._pending_zone = {
+            CONF_NAME: str(user_input[CONF_NAME]).strip(),
+            CONF_ENABLED: user_input[CONF_ENABLED],
+            CONF_CONTROL_TYPE: user_input[CONF_CONTROL_TYPE],
+            CONF_TARGET_SOURCE: user_input[CONF_TARGET_SOURCE],
+            CONF_TARGET_ENTITY_ID: user_input[CONF_TARGET_ENTITY_ID],
+            CONF_FROST_PROTECTION_MIN_TEMP: user_input.get(
+                CONF_FROST_PROTECTION_MIN_TEMP
+            ),
+        }
+
+    def _build_climate_zone(self, user_input: dict[str, object]) -> dict[str, object]:
+        """Build a complete climate-zone config from pending and detail input."""
+        assert self._pending_zone is not None
+        return {
+            **self._pending_zone,
+            CONF_SENSOR_ENTITY_IDS: user_input[CONF_SENSOR_ENTITY_IDS],
+            CONF_CLIMATE_ENTITY_IDS: user_input[CONF_CLIMATE_ENTITY_IDS],
+            CONF_CLIMATE_OFF_FALLBACK_TEMPERATURE: user_input.get(
+                CONF_CLIMATE_OFF_FALLBACK_TEMPERATURE
+            ),
+            CONF_LOCAL_GROUPS: [],
+            CONF_AGGREGATION_MODE: user_input[CONF_AGGREGATION_MODE],
+            CONF_PRIMARY_SENSOR_ENTITY_ID: user_input.get(CONF_PRIMARY_SENSOR_ENTITY_ID),
+        }
+
+    def _build_local_group(self, user_input: dict[str, object]) -> dict[str, object]:
+        """Build a local-group config from the current step input."""
+        zone_control_type = self._pending_zone_control_type()
+        assert zone_control_type is not None
+        return {
+            CONF_NAME: str(user_input[CONF_NAME]).strip(),
+            CONF_CONTROL_TYPE: zone_control_type,
+            CONF_SENSOR_ENTITY_IDS: user_input[CONF_SENSOR_ENTITY_IDS],
+            CONF_ACTUATOR_ENTITY_IDS: user_input[CONF_ACTUATOR_ENTITY_IDS],
+            CONF_AGGREGATION_MODE: user_input[CONF_AGGREGATION_MODE],
+            CONF_PRIMARY_SENSOR_ENTITY_ID: user_input.get(CONF_PRIMARY_SENSOR_ENTITY_ID),
+            CONF_NUMBER_SEMANTIC_TYPE: user_input.get(CONF_NUMBER_SEMANTIC_TYPE),
+            CONF_ACTIVE_VALUE: user_input.get(CONF_ACTIVE_VALUE),
+            CONF_INACTIVE_VALUE: user_input.get(CONF_INACTIVE_VALUE),
+        }
+
+    def _build_non_climate_zone(self) -> dict[str, object]:
+        """Build a complete switch or number zone from pending state."""
+        assert self._pending_zone is not None
+        return {
+            **self._pending_zone,
+            CONF_SENSOR_ENTITY_IDS: [],
+            CONF_CLIMATE_ENTITY_IDS: [],
+            CONF_LOCAL_GROUPS: deepcopy(self._pending_local_groups),
+            CONF_AGGREGATION_MODE: AggregationMode.AVERAGE,
+            CONF_PRIMARY_SENSOR_ENTITY_ID: None,
+        }
 
     def _add_zone(self, zone: dict[str, object]) -> None:
         """Append a completed zone to the working config."""
@@ -533,3 +483,525 @@ class MultiZoneHeatingConfigFlow(ConfigFlow, domain=DOMAIN):
         zones = self._config.setdefault(CONF_ZONES, [])
         assert isinstance(zones, list)
         zones.append(zone)
+
+    def _upsert_zone(self, zone: dict[str, object]) -> None:
+        """Insert or replace a zone in the working config."""
+        zones = self._zones()
+        if self._editing_zone_index is None:
+            zones.append(zone)
+        else:
+            zones[self._editing_zone_index] = zone
+        self._config[CONF_ZONES] = zones
+
+    def _clear_pending_zone(self) -> None:
+        """Reset any in-progress zone editing state."""
+        self._pending_zone = None
+        self._pending_local_groups = []
+        self._editing_zone_index = None
+        self._editing_local_group_index = None
+
+    def _zones(self) -> list[dict[str, object]]:
+        """Return a mutable copy of the configured zones."""
+        return deepcopy(list(self._config.get(CONF_ZONES, [])))
+
+    def _zone_label(self, zone: dict[str, object]) -> str:
+        """Return a human-readable label for a zone."""
+        return f"{zone[CONF_NAME]} ({zone[CONF_CONTROL_TYPE]})"
+
+    def _group_label(self, group: dict[str, object]) -> str:
+        """Return a human-readable label for a local group."""
+        return str(group[CONF_NAME])
+
+    def _global_defaults(self) -> dict[str, object]:
+        """Build suggested values for the global form."""
+        return {
+            CONF_NAME: self._title,
+            CONF_MAIN_RELAY_ENTITY_ID: self._config.get(CONF_MAIN_RELAY_ENTITY_ID),
+            CONF_FLOW_SENSOR_ENTITY_ID: self._config.get(CONF_FLOW_SENSOR_ENTITY_ID),
+            CONF_FLOW_DETECTION_THRESHOLD: self._config.get(CONF_FLOW_DETECTION_THRESHOLD),
+            CONF_MISSING_FLOW_TIMEOUT_SECONDS: self._config.get(
+                CONF_MISSING_FLOW_TIMEOUT_SECONDS,
+                DEFAULT_MISSING_FLOW_TIMEOUT_SECONDS,
+            ),
+            CONF_DEFAULT_HYSTERESIS: self._config.get(
+                CONF_DEFAULT_HYSTERESIS, DEFAULT_HYSTERESIS
+            ),
+            CONF_MIN_RELAY_ON_TIME_SECONDS: self._config.get(
+                CONF_MIN_RELAY_ON_TIME_SECONDS,
+                DEFAULT_MIN_RELAY_ON_TIME_SECONDS,
+            ),
+            CONF_MIN_RELAY_OFF_TIME_SECONDS: self._config.get(
+                CONF_MIN_RELAY_OFF_TIME_SECONDS,
+                DEFAULT_MIN_RELAY_OFF_TIME_SECONDS,
+            ),
+            CONF_RELAY_OFF_DELAY_SECONDS: self._config.get(
+                CONF_RELAY_OFF_DELAY_SECONDS,
+                DEFAULT_RELAY_OFF_DELAY_SECONDS,
+            ),
+            CONF_FROST_PROTECTION_MIN_TEMP: self._config.get(
+                CONF_FROST_PROTECTION_MIN_TEMP
+            ),
+        }
+
+    def _zone_defaults(self) -> dict[str, object] | None:
+        """Build suggested values for the zone basics form."""
+        if self._editing_zone_index is None:
+            return None
+        zone = self._zones()[self._editing_zone_index]
+        return {
+            CONF_NAME: zone[CONF_NAME],
+            CONF_ENABLED: zone.get(CONF_ENABLED, True),
+            CONF_CONTROL_TYPE: zone[CONF_CONTROL_TYPE],
+            CONF_TARGET_SOURCE: zone[CONF_TARGET_SOURCE],
+            CONF_TARGET_ENTITY_ID: zone[CONF_TARGET_ENTITY_ID],
+            CONF_FROST_PROTECTION_MIN_TEMP: zone.get(CONF_FROST_PROTECTION_MIN_TEMP),
+        }
+
+    def _climate_zone_defaults(self) -> dict[str, object] | None:
+        """Build suggested values for the climate-zone detail form."""
+        if self._editing_zone_index is None:
+            return None
+        zone = self._zones()[self._editing_zone_index]
+        if zone[CONF_CONTROL_TYPE] != ControlType.CLIMATE:
+            return None
+        return {
+            CONF_SENSOR_ENTITY_IDS: zone.get(CONF_SENSOR_ENTITY_IDS, []),
+            CONF_CLIMATE_ENTITY_IDS: zone.get(CONF_CLIMATE_ENTITY_IDS, []),
+            CONF_CLIMATE_OFF_FALLBACK_TEMPERATURE: zone.get(
+                CONF_CLIMATE_OFF_FALLBACK_TEMPERATURE
+            ),
+            CONF_AGGREGATION_MODE: zone.get(CONF_AGGREGATION_MODE, AggregationMode.AVERAGE),
+            CONF_PRIMARY_SENSOR_ENTITY_ID: zone.get(CONF_PRIMARY_SENSOR_ENTITY_ID),
+        }
+
+    def _local_group_defaults(self) -> dict[str, object] | None:
+        """Build suggested values for the local-group detail form."""
+        if self._editing_local_group_index is None:
+            return None
+        group = self._pending_local_groups[self._editing_local_group_index]
+        return {
+            CONF_NAME: group[CONF_NAME],
+            CONF_SENSOR_ENTITY_IDS: group.get(CONF_SENSOR_ENTITY_IDS, []),
+            CONF_ACTUATOR_ENTITY_IDS: group.get(CONF_ACTUATOR_ENTITY_IDS, []),
+            CONF_AGGREGATION_MODE: group.get(CONF_AGGREGATION_MODE, AggregationMode.AVERAGE),
+            CONF_PRIMARY_SENSOR_ENTITY_ID: group.get(CONF_PRIMARY_SENSOR_ENTITY_ID),
+            CONF_NUMBER_SEMANTIC_TYPE: group.get(CONF_NUMBER_SEMANTIC_TYPE),
+            CONF_ACTIVE_VALUE: group.get(CONF_ACTIVE_VALUE),
+            CONF_INACTIVE_VALUE: group.get(CONF_INACTIVE_VALUE),
+        }
+
+
+class MultiZoneHeatingConfigFlow(_MultiZoneHeatingFlowBase, ConfigFlow, domain=DOMAIN):
+    """Config flow for setting up a multi-zone heating system."""
+
+    VERSION = 1
+
+    def __init__(self) -> None:
+        """Initialize the config flow."""
+        super().__init__()
+
+    @staticmethod
+    @callback
+    def async_get_options_flow(
+        config_entry: ConfigEntry,
+    ) -> MultiZoneHeatingOptionsFlow:
+        """Create the options flow."""
+        return MultiZoneHeatingOptionsFlow(config_entry)
+
+    async def async_step_user(
+        self,
+        user_input: dict[str, object] | None = None,
+    ):
+        """Handle the initial global system setup step."""
+        errors: dict[str, str] = {}
+
+        if user_input is not None:
+            errors = self._validate_global_config(user_input)
+            if not errors:
+                await self.async_set_unique_id(DOMAIN)
+                self._abort_if_unique_id_configured()
+                self._save_global_config(user_input)
+                return await self.async_step_zone()
+
+        data_schema = self._global_schema(user_input)
+        return self.async_show_form(
+            step_id="user",
+            data_schema=data_schema,
+            errors=errors,
+        )
+
+    async def async_step_zone(
+        self,
+        user_input: dict[str, object] | None = None,
+    ):
+        """Collect the shared configuration for a zone."""
+        errors: dict[str, str] = {}
+
+        if user_input is not None:
+            errors = self._validate_zone_basics(user_input)
+            if not errors:
+                self._build_pending_zone(user_input)
+                self._pending_local_groups = []
+
+                if user_input[CONF_CONTROL_TYPE] == ControlType.CLIMATE:
+                    return await self.async_step_climate_zone()
+
+                return await self.async_step_local_group()
+
+        return self.async_show_form(
+            step_id="zone",
+            data_schema=self._zone_basics_schema(user_input),
+            errors=errors,
+        )
+
+    async def async_step_climate_zone(
+        self,
+        user_input: dict[str, object] | None = None,
+    ):
+        """Collect climate-zone-specific settings."""
+        errors: dict[str, str] = {}
+
+        if user_input is not None:
+            errors = self._validate_climate_zone_details(user_input)
+            if not errors and self._pending_zone is not None:
+                self._add_zone(self._build_climate_zone(user_input))
+                self._clear_pending_zone()
+                return await self.async_step_zone_options()
+
+        return self.async_show_form(
+            step_id="climate_zone",
+            data_schema=self._climate_zone_schema(user_input),
+            errors=errors,
+        )
+
+    async def async_step_local_group(
+        self,
+        user_input: dict[str, object] | None = None,
+    ):
+        """Collect one local control group for a switch or number zone."""
+        errors: dict[str, str] = {}
+        zone_control_type = self._pending_zone_control_type()
+
+        if zone_control_type is None:
+            return await self.async_step_zone()
+
+        if user_input is not None:
+            errors = self._validate_local_group(user_input, zone_control_type)
+            if not errors:
+                self._pending_local_groups.append(self._build_local_group(user_input))
+                return await self.async_step_local_group_options()
+
+        return self.async_show_form(
+            step_id="local_group",
+            data_schema=self._local_group_schema(zone_control_type, user_input),
+            errors=errors,
+        )
+
+    async def async_step_local_group_options(
+        self,
+        user_input: dict[str, object] | None = None,
+    ):
+        """Decide whether to add more local control groups."""
+        if self._pending_zone is None:
+            return await self.async_step_zone()
+
+        if user_input is not None:
+            if user_input["add_another_group"]:
+                return await self.async_step_local_group()
+
+            self._add_zone(self._build_non_climate_zone())
+            self._clear_pending_zone()
+            return await self.async_step_zone_options()
+
+        return self.async_show_form(
+            step_id="local_group_options",
+            data_schema=self._local_group_options_schema(),
+        )
+
+    async def async_step_zone_options(
+        self,
+        user_input: dict[str, object] | None = None,
+    ):
+        """Decide whether to add another zone or finish setup."""
+        if user_input is not None:
+            if user_input["add_another_zone"]:
+                return await self.async_step_zone()
+
+            return self.async_create_entry(title=self._title, data=self._config)
+
+        return self.async_show_form(
+            step_id="zone_options",
+            data_schema=self._zone_options_schema(),
+        )
+
+
+class MultiZoneHeatingOptionsFlow(
+    _MultiZoneHeatingFlowBase, OptionsFlowWithConfigEntry
+):
+    """Options flow for editing an existing multi-zone heating setup."""
+
+    def __init__(self, config_entry: ConfigEntry) -> None:
+        """Initialize the options flow."""
+        OptionsFlowWithConfigEntry.__init__(self, config_entry)
+        _MultiZoneHeatingFlowBase.__init__(self)
+        self._title = config_entry.title
+        self._config = deepcopy(dict(config_entry.data))
+        self._config.update(deepcopy(dict(config_entry.options)))
+
+    async def async_step_init(
+        self,
+        user_input: dict[str, object] | None = None,
+    ):
+        """Choose what part of the configuration to edit."""
+        if user_input is not None:
+            action = user_input[CONF_ACTION]
+            if action == ACTION_EDIT_GLOBALS:
+                return await self.async_step_edit_globals()
+            if action == ACTION_ADD_ZONE:
+                self._clear_pending_zone()
+                return await self.async_step_zone()
+            if action == ACTION_EDIT_ZONE:
+                return await self.async_step_select_zone_to_edit()
+            if action == ACTION_REMOVE_ZONE:
+                return await self.async_step_select_zone_to_remove()
+            return self.async_create_entry(title=self._title, data=self._config)
+
+        actions = [
+            {"value": ACTION_EDIT_GLOBALS, "label": "Edit global settings"},
+            {"value": ACTION_ADD_ZONE, "label": "Add zone"},
+        ]
+        if self._config.get(CONF_ZONES):
+            actions.extend(
+                [
+                    {"value": ACTION_EDIT_ZONE, "label": "Edit zone"},
+                    {"value": ACTION_REMOVE_ZONE, "label": "Remove zone"},
+                ]
+            )
+        actions.append({"value": ACTION_DONE, "label": "Save changes"})
+
+        return self.async_show_form(
+            step_id="init",
+            data_schema=self._action_schema(actions),
+        )
+
+    async def async_step_edit_globals(
+        self,
+        user_input: dict[str, object] | None = None,
+    ):
+        """Edit global integration settings."""
+        errors: dict[str, str] = {}
+
+        if user_input is not None:
+            errors = self._validate_global_config(user_input)
+            if not errors:
+                self._save_global_config(user_input)
+                self.hass.config_entries.async_update_entry(
+                    self.config_entry,
+                    title=self._title,
+                )
+                return await self.async_step_init()
+
+        defaults = user_input or self._global_defaults()
+        return self.async_show_form(
+            step_id="edit_globals",
+            data_schema=self._global_schema(defaults),
+            errors=errors,
+        )
+
+    async def async_step_select_zone_to_edit(
+        self,
+        user_input: dict[str, object] | None = None,
+    ):
+        """Choose an existing zone to edit."""
+        zones = self._zones()
+
+        if user_input is not None:
+            self._editing_zone_index = int(user_input[CONF_ZONE])
+            self._editing_local_group_index = None
+            return await self.async_step_zone()
+
+        return self.async_show_form(
+            step_id="select_zone_to_edit",
+            data_schema=self._zone_select_schema(zones),
+        )
+
+    async def async_step_select_zone_to_remove(
+        self,
+        user_input: dict[str, object] | None = None,
+    ):
+        """Choose an existing zone to remove."""
+        zones = self._zones()
+
+        if user_input is not None:
+            zone_index = int(user_input[CONF_ZONE])
+            zones.pop(zone_index)
+            self._config[CONF_ZONES] = zones
+            return await self.async_step_init()
+
+        return self.async_show_form(
+            step_id="select_zone_to_remove",
+            data_schema=self._zone_select_schema(zones),
+        )
+
+    async def async_step_zone(
+        self,
+        user_input: dict[str, object] | None = None,
+    ):
+        """Add or edit the shared configuration for a zone."""
+        errors: dict[str, str] = {}
+
+        if user_input is not None:
+            errors = self._validate_zone_basics(user_input)
+            if not errors:
+                self._build_pending_zone(user_input)
+                selected_zone = None
+                if self._editing_zone_index is not None:
+                    selected_zone = self._zones()[self._editing_zone_index]
+
+                if user_input[CONF_CONTROL_TYPE] == ControlType.CLIMATE:
+                    self._pending_local_groups = []
+                    return await self.async_step_climate_zone()
+
+                if (
+                    selected_zone is not None
+                    and selected_zone[CONF_CONTROL_TYPE] == user_input[CONF_CONTROL_TYPE]
+                ):
+                    self._pending_local_groups = deepcopy(
+                        list(selected_zone.get(CONF_LOCAL_GROUPS, []))
+                    )
+                else:
+                    self._pending_local_groups = []
+
+                if self._pending_local_groups:
+                    return await self.async_step_manage_local_groups()
+
+                self._editing_local_group_index = None
+                return await self.async_step_local_group()
+
+        defaults = user_input or self._zone_defaults()
+        return self.async_show_form(
+            step_id="zone",
+            data_schema=self._zone_basics_schema(defaults),
+            errors=errors,
+        )
+
+    async def async_step_climate_zone(
+        self,
+        user_input: dict[str, object] | None = None,
+    ):
+        """Add or edit climate-zone-specific settings."""
+        errors: dict[str, str] = {}
+
+        if user_input is not None:
+            errors = self._validate_climate_zone_details(user_input)
+            if not errors:
+                self._upsert_zone(self._build_climate_zone(user_input))
+                self._clear_pending_zone()
+                return await self.async_step_init()
+
+        defaults = user_input or self._climate_zone_defaults()
+        return self.async_show_form(
+            step_id="climate_zone",
+            data_schema=self._climate_zone_schema(defaults),
+            errors=errors,
+        )
+
+    async def async_step_manage_local_groups(
+        self,
+        user_input: dict[str, object] | None = None,
+    ):
+        """Manage the local groups for the pending non-climate zone."""
+        errors: dict[str, str] = {}
+
+        if self._pending_zone is None:
+            return await self.async_step_init()
+
+        if user_input is not None:
+            action = user_input[CONF_ACTION]
+            if action == ACTION_ADD_GROUP:
+                self._editing_local_group_index = None
+                return await self.async_step_local_group()
+            if action == ACTION_EDIT_GROUP:
+                return await self.async_step_select_group_to_edit()
+            if action == ACTION_REMOVE_GROUP:
+                return await self.async_step_select_group_to_remove()
+            if not self._pending_local_groups:
+                errors = {"base": "zone_requires_local_groups"}
+            else:
+                self._upsert_zone(self._build_non_climate_zone())
+                self._clear_pending_zone()
+                return await self.async_step_init()
+
+        actions = [{"value": ACTION_ADD_GROUP, "label": "Add local group"}]
+        if self._pending_local_groups:
+            actions.extend(
+                [
+                    {"value": ACTION_EDIT_GROUP, "label": "Edit local group"},
+                    {"value": ACTION_REMOVE_GROUP, "label": "Remove local group"},
+                    {"value": ACTION_DONE, "label": "Done with zone"},
+                ]
+            )
+
+        return self.async_show_form(
+            step_id="manage_local_groups",
+            data_schema=self._action_schema(actions),
+            errors=errors,
+        )
+
+    async def async_step_select_group_to_edit(
+        self,
+        user_input: dict[str, object] | None = None,
+    ):
+        """Choose a local group to edit."""
+        if user_input is not None:
+            self._editing_local_group_index = int(user_input[CONF_GROUP])
+            return await self.async_step_local_group()
+
+        return self.async_show_form(
+            step_id="select_group_to_edit",
+            data_schema=self._group_select_schema(self._pending_local_groups),
+        )
+
+    async def async_step_select_group_to_remove(
+        self,
+        user_input: dict[str, object] | None = None,
+    ):
+        """Choose a local group to remove."""
+        if user_input is not None:
+            group_index = int(user_input[CONF_GROUP])
+            self._pending_local_groups.pop(group_index)
+            return await self.async_step_manage_local_groups()
+
+        return self.async_show_form(
+            step_id="select_group_to_remove",
+            data_schema=self._group_select_schema(self._pending_local_groups),
+        )
+
+    async def async_step_local_group(
+        self,
+        user_input: dict[str, object] | None = None,
+    ):
+        """Add or edit one local control group for a switch or number zone."""
+        errors: dict[str, str] = {}
+        zone_control_type = self._pending_zone_control_type()
+
+        if zone_control_type is None:
+            return await self.async_step_init()
+
+        if user_input is not None:
+            errors = self._validate_local_group(user_input, zone_control_type)
+            if not errors:
+                group = self._build_local_group(user_input)
+                if self._editing_local_group_index is None:
+                    self._pending_local_groups.append(group)
+                else:
+                    self._pending_local_groups[self._editing_local_group_index] = group
+                self._editing_local_group_index = None
+                return await self.async_step_manage_local_groups()
+
+        defaults = user_input or self._local_group_defaults()
+        return self.async_show_form(
+            step_id="local_group",
+            data_schema=self._local_group_schema(zone_control_type, defaults),
+            errors=errors,
+        )

--- a/custom_components/multi_zone_heating/coordinator.py
+++ b/custom_components/multi_zone_heating/coordinator.py
@@ -129,12 +129,20 @@ class MultiZoneHeatingCoordinator(DataUpdateCoordinator[RuntimeSnapshot]):
         config_entry: ConfigEntry | None = None,
     ) -> None:
         """Initialize the coordinator."""
-        super().__init__(
-            hass,
-            _LOGGER,
-            name="multi_zone_heating",
-            config_entry=config_entry,
-        )
+        try:
+            super().__init__(
+                hass,
+                _LOGGER,
+                name="multi_zone_heating",
+                config_entry=config_entry,
+            )
+        except TypeError:
+            super().__init__(
+                hass,
+                _LOGGER,
+                name="multi_zone_heating",
+            )
+            self.config_entry = config_entry
         self.config = config
         self._unsub_state_changes: CALLBACK_TYPE | None = None
         self._unsub_recheck: CALLBACK_TYPE | None = None

--- a/custom_components/multi_zone_heating/strings.json
+++ b/custom_components/multi_zone_heating/strings.json
@@ -86,5 +86,117 @@
         }
       }
     }
+  },
+  "options": {
+    "error": {
+      "flow_threshold_required": "Provide a flow threshold when a flow sensor is configured.",
+      "group_name_required": "Each local control group needs a name.",
+      "group_requires_actuators": "Each local control group needs at least one actuator.",
+      "group_requires_sensors": "Each local control group needs at least one temperature sensor.",
+      "number_values_required": "Number control groups need active and inactive values.",
+      "primary_sensor_not_in_sensors": "The primary sensor must be one of the selected sensors.",
+      "primary_sensor_required": "Select a primary sensor when using primary aggregation.",
+      "target_entity_domain_mismatch": "The target entity must match the selected target source type.",
+      "zone_name_required": "Each zone needs a name.",
+      "zone_requires_climate_entities": "Climate zones need at least one climate entity.",
+      "zone_requires_local_groups": "Switch and number zones need at least one local control group.",
+      "zone_requires_sensors": "Climate zones need at least one temperature sensor."
+    },
+    "step": {
+      "init": {
+        "title": "Edit Multi-Zone Heating",
+        "description": "Choose what part of the integration configuration to edit.",
+        "data": {
+          "action": "Action"
+        }
+      },
+      "edit_globals": {
+        "title": "Edit Global Settings",
+        "description": "Update shared relay, flow, timing, and frost settings.",
+        "data": {
+          "default_hysteresis": "Default hysteresis",
+          "flow_detection_threshold": "Flow detection threshold",
+          "flow_sensor_entity_id": "Flow meter entity",
+          "frost_protection_min_temp": "Global frost minimum",
+          "main_relay_entity_id": "Main relay entity",
+          "min_relay_off_time_seconds": "Minimum relay off time (seconds)",
+          "min_relay_on_time_seconds": "Minimum relay on time (seconds)",
+          "name": "Name",
+          "relay_off_delay_seconds": "Relay off delay (seconds)"
+        }
+      },
+      "select_zone_to_edit": {
+        "title": "Select Zone",
+        "description": "Choose the zone you want to edit.",
+        "data": {
+          "zone": "Zone"
+        }
+      },
+      "select_zone_to_remove": {
+        "title": "Remove Zone",
+        "description": "Choose the zone you want to remove.",
+        "data": {
+          "zone": "Zone"
+        }
+      },
+      "zone": {
+        "title": "Edit Zone",
+        "description": "Update the shared settings for this heating zone.",
+        "data": {
+          "control_type": "Control type",
+          "enabled": "Enabled",
+          "frost_protection_min_temp": "Zone frost minimum",
+          "name": "Zone name",
+          "target_entity_id": "Target entity",
+          "target_source": "Target source"
+        }
+      },
+      "climate_zone": {
+        "title": "Climate Zone Details",
+        "description": "Choose the sensors and climate entities used by this zone.",
+        "data": {
+          "aggregation_mode": "Temperature aggregation mode",
+          "climate_entity_ids": "Climate entities",
+          "climate_off_fallback_temperature": "Fallback target when off is unsupported",
+          "primary_sensor_entity_id": "Primary sensor",
+          "sensor_entity_ids": "Temperature sensors"
+        }
+      },
+      "manage_local_groups": {
+        "title": "Manage Local Groups",
+        "description": "Add, edit, or remove the local control groups for this zone.",
+        "data": {
+          "action": "Action"
+        }
+      },
+      "select_group_to_edit": {
+        "title": "Select Local Group",
+        "description": "Choose the local group you want to edit.",
+        "data": {
+          "group": "Local group"
+        }
+      },
+      "select_group_to_remove": {
+        "title": "Remove Local Group",
+        "description": "Choose the local group you want to remove.",
+        "data": {
+          "group": "Local group"
+        }
+      },
+      "local_group": {
+        "title": "Local Control Group",
+        "description": "Configure one local sensor-and-actuator group for this zone.",
+        "data": {
+          "active_value": "Active value",
+          "actuator_entity_ids": "Actuator entities",
+          "aggregation_mode": "Temperature aggregation mode",
+          "inactive_value": "Inactive value",
+          "name": "Group name",
+          "number_semantic_type": "Number semantic type",
+          "primary_sensor_entity_id": "Primary sensor",
+          "sensor_entity_ids": "Temperature sensors"
+        }
+      }
+    }
   }
 }

--- a/custom_components/multi_zone_heating/translations/en.json
+++ b/custom_components/multi_zone_heating/translations/en.json
@@ -86,5 +86,117 @@
         }
       }
     }
+  },
+  "options": {
+    "error": {
+      "flow_threshold_required": "Provide a flow threshold when a flow sensor is configured.",
+      "group_name_required": "Each local control group needs a name.",
+      "group_requires_actuators": "Each local control group needs at least one actuator.",
+      "group_requires_sensors": "Each local control group needs at least one temperature sensor.",
+      "number_values_required": "Number control groups need active and inactive values.",
+      "primary_sensor_not_in_sensors": "The primary sensor must be one of the selected sensors.",
+      "primary_sensor_required": "Select a primary sensor when using primary aggregation.",
+      "target_entity_domain_mismatch": "The target entity must match the selected target source type.",
+      "zone_name_required": "Each zone needs a name.",
+      "zone_requires_climate_entities": "Climate zones need at least one climate entity.",
+      "zone_requires_local_groups": "Switch and number zones need at least one local control group.",
+      "zone_requires_sensors": "Climate zones need at least one temperature sensor."
+    },
+    "step": {
+      "init": {
+        "title": "Edit Multi-Zone Heating",
+        "description": "Choose what part of the integration configuration to edit.",
+        "data": {
+          "action": "Action"
+        }
+      },
+      "edit_globals": {
+        "title": "Edit Global Settings",
+        "description": "Update shared relay, flow, timing, and frost settings.",
+        "data": {
+          "default_hysteresis": "Default hysteresis",
+          "flow_detection_threshold": "Flow detection threshold",
+          "flow_sensor_entity_id": "Flow meter entity",
+          "frost_protection_min_temp": "Global frost minimum",
+          "main_relay_entity_id": "Main relay entity",
+          "min_relay_off_time_seconds": "Minimum relay off time (seconds)",
+          "min_relay_on_time_seconds": "Minimum relay on time (seconds)",
+          "name": "Name",
+          "relay_off_delay_seconds": "Relay off delay (seconds)"
+        }
+      },
+      "select_zone_to_edit": {
+        "title": "Select Zone",
+        "description": "Choose the zone you want to edit.",
+        "data": {
+          "zone": "Zone"
+        }
+      },
+      "select_zone_to_remove": {
+        "title": "Remove Zone",
+        "description": "Choose the zone you want to remove.",
+        "data": {
+          "zone": "Zone"
+        }
+      },
+      "zone": {
+        "title": "Edit Zone",
+        "description": "Update the shared settings for this heating zone.",
+        "data": {
+          "control_type": "Control type",
+          "enabled": "Enabled",
+          "frost_protection_min_temp": "Zone frost minimum",
+          "name": "Zone name",
+          "target_entity_id": "Target entity",
+          "target_source": "Target source"
+        }
+      },
+      "climate_zone": {
+        "title": "Climate Zone Details",
+        "description": "Choose the sensors and climate entities used by this zone.",
+        "data": {
+          "aggregation_mode": "Temperature aggregation mode",
+          "climate_entity_ids": "Climate entities",
+          "climate_off_fallback_temperature": "Fallback target when off is unsupported",
+          "primary_sensor_entity_id": "Primary sensor",
+          "sensor_entity_ids": "Temperature sensors"
+        }
+      },
+      "manage_local_groups": {
+        "title": "Manage Local Groups",
+        "description": "Add, edit, or remove the local control groups for this zone.",
+        "data": {
+          "action": "Action"
+        }
+      },
+      "select_group_to_edit": {
+        "title": "Select Local Group",
+        "description": "Choose the local group you want to edit.",
+        "data": {
+          "group": "Local group"
+        }
+      },
+      "select_group_to_remove": {
+        "title": "Remove Local Group",
+        "description": "Choose the local group you want to remove.",
+        "data": {
+          "group": "Local group"
+        }
+      },
+      "local_group": {
+        "title": "Local Control Group",
+        "description": "Configure one local sensor-and-actuator group for this zone.",
+        "data": {
+          "active_value": "Active value",
+          "actuator_entity_ids": "Actuator entities",
+          "aggregation_mode": "Temperature aggregation mode",
+          "inactive_value": "Inactive value",
+          "name": "Group name",
+          "number_semantic_type": "Number semantic type",
+          "primary_sensor_entity_id": "Primary sensor",
+          "sensor_entity_ids": "Temperature sensors"
+        }
+      }
+    }
   }
 }

--- a/tests/components/multi_zone_heating/test_config_flow.py
+++ b/tests/components/multi_zone_heating/test_config_flow.py
@@ -828,6 +828,57 @@ async def test_options_flow_can_add_and_remove_zones_and_local_groups(hass) -> N
     ]
 
 
+async def test_options_flow_requires_local_group_before_finishing_non_climate_zone(hass) -> None:
+    """Switch and number zones should not be savable without a local group."""
+    config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        title="Original Heating",
+        data=_existing_config(),
+        version=1,
+    )
+    config_entry.add_to_hass(hass)
+
+    result = await hass.config_entries.options.async_init(config_entry.entry_id)
+    result = await hass.config_entries.options.async_configure(
+        result["flow_id"],
+        {CONF_ACTION: ACTION_EDIT_ZONE},
+    )
+    result = await hass.config_entries.options.async_configure(
+        result["flow_id"],
+        {CONF_ZONE: "0"},
+    )
+    result = await hass.config_entries.options.async_configure(
+        result["flow_id"],
+        {
+            CONF_NAME: "Bedroom",
+            CONF_ENABLED: True,
+            CONF_CONTROL_TYPE: ControlType.SWITCH,
+            CONF_TARGET_SOURCE: TargetSourceType.INPUT_NUMBER,
+            CONF_TARGET_ENTITY_ID: "input_number.bedroom_target",
+        },
+    )
+    assert result["step_id"] == "manage_local_groups"
+
+    result = await hass.config_entries.options.async_configure(
+        result["flow_id"],
+        {CONF_ACTION: ACTION_REMOVE_GROUP},
+    )
+    result = await hass.config_entries.options.async_configure(
+        result["flow_id"],
+        {CONF_GROUP: "0"},
+    )
+    assert result["step_id"] == "manage_local_groups"
+
+    result = await hass.config_entries.options.async_configure(
+        result["flow_id"],
+        {CONF_ACTION: ACTION_DONE},
+    )
+
+    assert result["type"] is data_entry_flow.FlowResultType.FORM
+    assert result["step_id"] == "manage_local_groups"
+    assert result["errors"] == {"base": "zone_requires_local_groups"}
+
+
 async def test_single_instance_flow_aborts_when_entry_exists(hass, config_entry) -> None:
     """Only one config entry should be allowed."""
     config_entry.add_to_hass(hass)

--- a/tests/components/multi_zone_heating/test_config_flow.py
+++ b/tests/components/multi_zone_heating/test_config_flow.py
@@ -7,6 +7,15 @@ from homeassistant.const import CONF_NAME
 
 from custom_components.multi_zone_heating.const import DEFAULT_TITLE, DOMAIN
 from custom_components.multi_zone_heating.config_flow import (
+    ACTION_ADD_GROUP,
+    ACTION_ADD_ZONE,
+    ACTION_DONE,
+    ACTION_EDIT_GLOBALS,
+    ACTION_EDIT_GROUP,
+    ACTION_EDIT_ZONE,
+    ACTION_REMOVE_GROUP,
+    ACTION_REMOVE_ZONE,
+    CONF_ACTION,
     CONF_ACTIVE_VALUE,
     CONF_ACTUATOR_ENTITY_IDS,
     CONF_AGGREGATION_MODE,
@@ -30,7 +39,9 @@ from custom_components.multi_zone_heating.config_flow import (
     CONF_SENSOR_ENTITY_IDS,
     CONF_TARGET_ENTITY_ID,
     CONF_TARGET_SOURCE,
+    CONF_ZONE,
     CONF_ZONES,
+    CONF_GROUP,
 )
 from custom_components.multi_zone_heating.models import (
     AggregationMode,
@@ -38,6 +49,7 @@ from custom_components.multi_zone_heating.models import (
     NumberSemanticType,
     TargetSourceType,
 )
+from pytest_homeassistant_custom_component.common import MockConfigEntry
 
 
 async def _start_basic_flow(hass, *, name: str = DEFAULT_TITLE):
@@ -60,6 +72,45 @@ async def _start_basic_flow(hass, *, name: str = DEFAULT_TITLE):
             CONF_RELAY_OFF_DELAY_SECONDS: 0,
         },
     )
+
+
+def _existing_config() -> dict[str, object]:
+    """Build a representative config-entry payload for options-flow tests."""
+    return {
+        CONF_MAIN_RELAY_ENTITY_ID: "switch.boiler_relay",
+        CONF_DEFAULT_HYSTERESIS: 0.3,
+        CONF_MIN_RELAY_ON_TIME_SECONDS: 0,
+        CONF_MIN_RELAY_OFF_TIME_SECONDS: 0,
+        CONF_RELAY_OFF_DELAY_SECONDS: 0,
+        CONF_FROST_PROTECTION_MIN_TEMP: 7.0,
+        CONF_ZONES: [
+            {
+                CONF_NAME: "Bedroom",
+                CONF_ENABLED: True,
+                CONF_CONTROL_TYPE: ControlType.SWITCH,
+                CONF_TARGET_SOURCE: TargetSourceType.INPUT_NUMBER,
+                CONF_TARGET_ENTITY_ID: "input_number.bedroom_target",
+                CONF_FROST_PROTECTION_MIN_TEMP: None,
+                CONF_SENSOR_ENTITY_IDS: [],
+                CONF_CLIMATE_ENTITY_IDS: [],
+                CONF_LOCAL_GROUPS: [
+                    {
+                        CONF_NAME: "Radiator",
+                        CONF_CONTROL_TYPE: ControlType.SWITCH,
+                        CONF_SENSOR_ENTITY_IDS: ["sensor.bedroom_temperature"],
+                        CONF_ACTUATOR_ENTITY_IDS: ["switch.bedroom_valve"],
+                        CONF_AGGREGATION_MODE: AggregationMode.AVERAGE,
+                        CONF_PRIMARY_SENSOR_ENTITY_ID: None,
+                        CONF_NUMBER_SEMANTIC_TYPE: None,
+                        CONF_ACTIVE_VALUE: None,
+                        CONF_INACTIVE_VALUE: None,
+                    }
+                ],
+                CONF_AGGREGATION_MODE: AggregationMode.AVERAGE,
+                CONF_PRIMARY_SENSOR_ENTITY_ID: None,
+            }
+        ],
+    }
 
 
 async def test_user_flow_creates_entry_for_climate_zone(hass) -> None:
@@ -526,7 +577,255 @@ async def test_climate_zone_requires_primary_sensor_when_primary_mode_selected(h
 
     assert result["type"] is data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "climate_zone"
-    assert result["errors"] == {"base": "primary_sensor_required"}
+
+
+async def test_options_flow_updates_globals_zone_and_local_group(hass) -> None:
+    """Options flow should support editing globals, zones, and local groups."""
+    config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        title="Original Heating",
+        data=_existing_config(),
+        version=1,
+    )
+    config_entry.add_to_hass(hass)
+
+    result = await hass.config_entries.options.async_init(config_entry.entry_id)
+    assert result["type"] is data_entry_flow.FlowResultType.FORM
+    assert result["step_id"] == "init"
+
+    result = await hass.config_entries.options.async_configure(
+        result["flow_id"],
+        {CONF_ACTION: ACTION_EDIT_GLOBALS},
+    )
+    assert result["step_id"] == "edit_globals"
+
+    result = await hass.config_entries.options.async_configure(
+        result["flow_id"],
+        {
+            CONF_NAME: "Edited Heating",
+            CONF_MAIN_RELAY_ENTITY_ID: "switch.updated_boiler_relay",
+            CONF_FLOW_SENSOR_ENTITY_ID: "sensor.system_flow",
+            CONF_FLOW_DETECTION_THRESHOLD: 1.5,
+            CONF_DEFAULT_HYSTERESIS: 0.45,
+            CONF_MIN_RELAY_ON_TIME_SECONDS: 60,
+            CONF_MIN_RELAY_OFF_TIME_SECONDS: 30,
+            CONF_RELAY_OFF_DELAY_SECONDS: 20,
+            CONF_FROST_PROTECTION_MIN_TEMP: 6.5,
+        },
+    )
+    assert result["step_id"] == "init"
+
+    result = await hass.config_entries.options.async_configure(
+        result["flow_id"],
+        {CONF_ACTION: ACTION_EDIT_ZONE},
+    )
+    assert result["step_id"] == "select_zone_to_edit"
+
+    result = await hass.config_entries.options.async_configure(
+        result["flow_id"],
+        {CONF_ZONE: "0"},
+    )
+    assert result["step_id"] == "zone"
+
+    result = await hass.config_entries.options.async_configure(
+        result["flow_id"],
+        {
+            CONF_NAME: "Main Bedroom",
+            CONF_ENABLED: True,
+            CONF_CONTROL_TYPE: ControlType.SWITCH,
+            CONF_TARGET_SOURCE: TargetSourceType.INPUT_NUMBER,
+            CONF_TARGET_ENTITY_ID: "input_number.main_bedroom_target",
+            CONF_FROST_PROTECTION_MIN_TEMP: 8.0,
+        },
+    )
+    assert result["step_id"] == "manage_local_groups"
+
+    result = await hass.config_entries.options.async_configure(
+        result["flow_id"],
+        {CONF_ACTION: ACTION_EDIT_GROUP},
+    )
+    assert result["step_id"] == "select_group_to_edit"
+
+    result = await hass.config_entries.options.async_configure(
+        result["flow_id"],
+        {CONF_GROUP: "0"},
+    )
+    assert result["step_id"] == "local_group"
+
+    result = await hass.config_entries.options.async_configure(
+        result["flow_id"],
+        {
+            CONF_NAME: "Main Radiator",
+            CONF_SENSOR_ENTITY_IDS: ["sensor.main_bedroom_temperature"],
+            CONF_ACTUATOR_ENTITY_IDS: ["switch.main_bedroom_valve"],
+            CONF_AGGREGATION_MODE: AggregationMode.MINIMUM,
+        },
+    )
+    assert result["step_id"] == "manage_local_groups"
+
+    result = await hass.config_entries.options.async_configure(
+        result["flow_id"],
+        {CONF_ACTION: ACTION_DONE},
+    )
+    assert result["step_id"] == "init"
+
+    result = await hass.config_entries.options.async_configure(
+        result["flow_id"],
+        {CONF_ACTION: ACTION_DONE},
+    )
+
+    assert result["type"] is data_entry_flow.FlowResultType.CREATE_ENTRY
+    assert config_entry.title == "Edited Heating"
+    assert result["data"][CONF_MAIN_RELAY_ENTITY_ID] == "switch.updated_boiler_relay"
+    assert result["data"][CONF_FLOW_SENSOR_ENTITY_ID] == "sensor.system_flow"
+    assert result["data"][CONF_FLOW_DETECTION_THRESHOLD] == 1.5
+    assert result["data"][CONF_DEFAULT_HYSTERESIS] == 0.45
+    assert result["data"][CONF_ZONES][0][CONF_NAME] == "Main Bedroom"
+    assert result["data"][CONF_ZONES][0][CONF_TARGET_ENTITY_ID] == "input_number.main_bedroom_target"
+    assert result["data"][CONF_ZONES][0][CONF_FROST_PROTECTION_MIN_TEMP] == 8.0
+    assert result["data"][CONF_ZONES][0][CONF_LOCAL_GROUPS][0][CONF_NAME] == "Main Radiator"
+    assert (
+        result["data"][CONF_ZONES][0][CONF_LOCAL_GROUPS][0][CONF_ACTUATOR_ENTITY_IDS]
+        == ["switch.main_bedroom_valve"]
+    )
+    assert (
+        result["data"][CONF_ZONES][0][CONF_LOCAL_GROUPS][0][CONF_AGGREGATION_MODE]
+        == AggregationMode.MINIMUM
+    )
+
+
+async def test_options_flow_can_add_and_remove_zones_and_local_groups(hass) -> None:
+    """Options flow should support adding and removing zones and groups."""
+    config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        title="Original Heating",
+        data=_existing_config(),
+        version=1,
+    )
+    config_entry.add_to_hass(hass)
+
+    result = await hass.config_entries.options.async_init(config_entry.entry_id)
+
+    result = await hass.config_entries.options.async_configure(
+        result["flow_id"],
+        {CONF_ACTION: ACTION_EDIT_ZONE},
+    )
+    result = await hass.config_entries.options.async_configure(
+        result["flow_id"],
+        {CONF_ZONE: "0"},
+    )
+    result = await hass.config_entries.options.async_configure(
+        result["flow_id"],
+        {
+            CONF_NAME: "Bedroom",
+            CONF_ENABLED: True,
+            CONF_CONTROL_TYPE: ControlType.SWITCH,
+            CONF_TARGET_SOURCE: TargetSourceType.INPUT_NUMBER,
+            CONF_TARGET_ENTITY_ID: "input_number.bedroom_target",
+        },
+    )
+    assert result["step_id"] == "manage_local_groups"
+
+    result = await hass.config_entries.options.async_configure(
+        result["flow_id"],
+        {CONF_ACTION: ACTION_ADD_GROUP},
+    )
+    assert result["step_id"] == "local_group"
+
+    result = await hass.config_entries.options.async_configure(
+        result["flow_id"],
+        {
+            CONF_NAME: "Desk Radiator",
+            CONF_SENSOR_ENTITY_IDS: ["sensor.desk_temperature"],
+            CONF_ACTUATOR_ENTITY_IDS: ["switch.desk_valve"],
+            CONF_AGGREGATION_MODE: AggregationMode.AVERAGE,
+        },
+    )
+    assert result["step_id"] == "manage_local_groups"
+
+    result = await hass.config_entries.options.async_configure(
+        result["flow_id"],
+        {CONF_ACTION: ACTION_REMOVE_GROUP},
+    )
+    assert result["step_id"] == "select_group_to_remove"
+
+    result = await hass.config_entries.options.async_configure(
+        result["flow_id"],
+        {CONF_GROUP: "0"},
+    )
+    assert result["step_id"] == "manage_local_groups"
+
+    result = await hass.config_entries.options.async_configure(
+        result["flow_id"],
+        {CONF_ACTION: ACTION_DONE},
+    )
+    assert result["step_id"] == "init"
+
+    result = await hass.config_entries.options.async_configure(
+        result["flow_id"],
+        {CONF_ACTION: ACTION_ADD_ZONE},
+    )
+    assert result["step_id"] == "zone"
+
+    result = await hass.config_entries.options.async_configure(
+        result["flow_id"],
+        {
+            CONF_NAME: "Living Room",
+            CONF_ENABLED: True,
+            CONF_CONTROL_TYPE: ControlType.CLIMATE,
+            CONF_TARGET_SOURCE: TargetSourceType.CLIMATE,
+            CONF_TARGET_ENTITY_ID: "climate.living_room_target",
+            CONF_FROST_PROTECTION_MIN_TEMP: 8.0,
+        },
+    )
+    assert result["step_id"] == "climate_zone"
+
+    result = await hass.config_entries.options.async_configure(
+        result["flow_id"],
+        {
+            CONF_SENSOR_ENTITY_IDS: ["sensor.living_room_temperature"],
+            CONF_CLIMATE_ENTITY_IDS: ["climate.living_room_radiator"],
+            CONF_CLIMATE_OFF_FALLBACK_TEMPERATURE: 7.0,
+            CONF_AGGREGATION_MODE: AggregationMode.PRIMARY,
+            CONF_PRIMARY_SENSOR_ENTITY_ID: "sensor.living_room_temperature",
+        },
+    )
+    assert result["step_id"] == "init"
+
+    result = await hass.config_entries.options.async_configure(
+        result["flow_id"],
+        {CONF_ACTION: ACTION_REMOVE_ZONE},
+    )
+    assert result["step_id"] == "select_zone_to_remove"
+
+    result = await hass.config_entries.options.async_configure(
+        result["flow_id"],
+        {CONF_ZONE: "0"},
+    )
+    assert result["step_id"] == "init"
+
+    result = await hass.config_entries.options.async_configure(
+        result["flow_id"],
+        {CONF_ACTION: ACTION_DONE},
+    )
+
+    assert result["type"] is data_entry_flow.FlowResultType.CREATE_ENTRY
+    assert result["data"][CONF_ZONES] == [
+        {
+            CONF_NAME: "Living Room",
+            CONF_ENABLED: True,
+            CONF_CONTROL_TYPE: ControlType.CLIMATE,
+            CONF_TARGET_SOURCE: TargetSourceType.CLIMATE,
+            CONF_TARGET_ENTITY_ID: "climate.living_room_target",
+            CONF_FROST_PROTECTION_MIN_TEMP: 8.0,
+            CONF_SENSOR_ENTITY_IDS: ["sensor.living_room_temperature"],
+            CONF_CLIMATE_ENTITY_IDS: ["climate.living_room_radiator"],
+            CONF_CLIMATE_OFF_FALLBACK_TEMPERATURE: 7.0,
+            CONF_LOCAL_GROUPS: [],
+            CONF_AGGREGATION_MODE: AggregationMode.PRIMARY,
+            CONF_PRIMARY_SENSOR_ENTITY_ID: "sensor.living_room_temperature",
+        }
+    ]
 
 
 async def test_single_instance_flow_aborts_when_entry_exists(hass, config_entry) -> None:

--- a/tests/components/multi_zone_heating/test_init.py
+++ b/tests/components/multi_zone_heating/test_init.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from unittest.mock import AsyncMock, patch
+
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.const import CONF_NAME
 
@@ -85,3 +87,24 @@ async def test_setup_entry_prefers_options_over_data(hass) -> None:
     assert config_entry.state is ConfigEntryState.LOADED
     assert config_entry.runtime_data.config.default_hysteresis == 0.6
     assert [zone.name for zone in config_entry.runtime_data.config.zones] == ["Living Room"]
+
+
+async def test_options_update_triggers_entry_reload(hass, config_entry) -> None:
+    """Updating entry options should reload the integration immediately."""
+    config_entry.add_to_hass(hass)
+
+    with patch.object(
+        hass.config_entries,
+        "async_reload",
+        AsyncMock(return_value=True),
+    ) as mock_reload:
+        assert await hass.config_entries.async_setup(config_entry.entry_id)
+        await hass.async_block_till_done()
+
+        hass.config_entries.async_update_entry(
+            config_entry,
+            options={CONF_DEFAULT_HYSTERESIS: 0.5},
+        )
+        await hass.async_block_till_done()
+
+    mock_reload.assert_awaited_once_with(config_entry.entry_id)

--- a/tests/components/multi_zone_heating/test_init.py
+++ b/tests/components/multi_zone_heating/test_init.py
@@ -3,10 +3,30 @@
 from __future__ import annotations
 
 from homeassistant.config_entries import ConfigEntryState
+from homeassistant.const import CONF_NAME
 
 from custom_components.multi_zone_heating.const import DOMAIN
+from custom_components.multi_zone_heating.config_flow import (
+    CONF_AGGREGATION_MODE,
+    CONF_CLIMATE_ENTITY_IDS,
+    CONF_CONTROL_TYPE,
+    CONF_DEFAULT_HYSTERESIS,
+    CONF_ENABLED,
+    CONF_LOCAL_GROUPS,
+    CONF_PRIMARY_SENSOR_ENTITY_ID,
+    CONF_SENSOR_ENTITY_IDS,
+    CONF_TARGET_ENTITY_ID,
+    CONF_TARGET_SOURCE,
+    CONF_ZONES,
+)
 from custom_components.multi_zone_heating.coordinator import MultiZoneHeatingCoordinator
-from custom_components.multi_zone_heating.models import RuntimeData
+from custom_components.multi_zone_heating.models import (
+    AggregationMode,
+    ControlType,
+    RuntimeData,
+    TargetSourceType,
+)
+from pytest_homeassistant_custom_component.common import MockConfigEntry
 
 
 async def test_setup_and_unload_entry(hass, config_entry) -> None:
@@ -26,3 +46,42 @@ async def test_setup_and_unload_entry(hass, config_entry) -> None:
 
     assert config_entry.state is ConfigEntryState.NOT_LOADED
     assert DOMAIN in hass.config.components
+
+
+async def test_setup_entry_prefers_options_over_data(hass) -> None:
+    """Runtime config should honor full replacement config stored in entry options."""
+    config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        title="Multi-Zone Heating",
+        data={
+            CONF_DEFAULT_HYSTERESIS: 0.3,
+            CONF_ZONES: [],
+        },
+        options={
+            CONF_DEFAULT_HYSTERESIS: 0.6,
+            CONF_ZONES: [
+                {
+                    CONF_NAME: "Living Room",
+                    CONF_ENABLED: True,
+                    CONF_CONTROL_TYPE: ControlType.CLIMATE,
+                    CONF_TARGET_SOURCE: TargetSourceType.CLIMATE,
+                    CONF_TARGET_ENTITY_ID: "climate.living_room_target",
+                    CONF_SENSOR_ENTITY_IDS: ["sensor.living_room_temperature"],
+                    CONF_CLIMATE_ENTITY_IDS: ["climate.living_room_radiator"],
+                    CONF_LOCAL_GROUPS: [],
+                    CONF_AGGREGATION_MODE: AggregationMode.AVERAGE,
+                    CONF_PRIMARY_SENSOR_ENTITY_ID: None,
+                }
+            ],
+        },
+        version=1,
+        state=ConfigEntryState.NOT_LOADED,
+    )
+    config_entry.add_to_hass(hass)
+
+    assert await hass.config_entries.async_setup(config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert config_entry.state is ConfigEntryState.LOADED
+    assert config_entry.runtime_data.config.default_hysteresis == 0.6
+    assert [zone.name for zone in config_entry.runtime_data.config.zones] == ["Living Room"]


### PR DESCRIPTION
## Summary
- add a full options flow for editing global settings, zones, and local control groups after setup
- reuse the existing validation rules in the edit flow and add translations for the new options steps
- apply config-entry options at runtime and cover the new editing paths with tests

## Validation
- `PYTHONPATH=. .venv/bin/pytest -q`

Closes #12