### PR TITLE
Review only: diagnostics export and CI coverage reporting

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,8 @@ permissions:
 jobs:
   release:
     runs-on: ubuntu-latest
+    env:
+      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
 
     steps:
       - name: Check out repository

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,4 +22,7 @@ jobs:
         run: python -m pip install -r requirements_test.txt
 
       - name: Run tests
-        run: python -m pytest -q
+        run: python -m coverage run -m pytest -q
+
+      - name: Report coverage
+        run: python -m coverage report -m

--- a/custom_components/multi_zone_heating/diagnostics.py
+++ b/custom_components/multi_zone_heating/diagnostics.py
@@ -1,0 +1,66 @@
+"""Diagnostics support for multi_zone_heating."""
+
+from __future__ import annotations
+
+from dataclasses import fields, is_dataclass
+from datetime import datetime
+from enum import Enum
+from typing import Any
+
+from homeassistant.core import HomeAssistant
+
+from . import MultiZoneHeatingConfigEntry
+
+
+async def async_get_config_entry_diagnostics(
+    hass: HomeAssistant,
+    entry: MultiZoneHeatingConfigEntry,
+) -> dict[str, Any]:
+    """Return diagnostics for a config entry."""
+    del hass
+
+    runtime_data = getattr(entry, "runtime_data", None)
+    coordinator = runtime_data.coordinator if runtime_data is not None else None
+
+    return {
+        "config_entry": {
+            "entry_id": entry.entry_id,
+            "title": entry.title,
+            "version": entry.version,
+            "minor_version": entry.minor_version,
+        },
+        "config": _serialize_value(runtime_data.config if runtime_data is not None else dict(entry.data)),
+        "runtime": {
+            "loaded": coordinator is not None,
+            "global_force_off": coordinator.data.global_force_off
+            if coordinator is not None and coordinator.data is not None
+            else None,
+            "snapshot": _serialize_value(coordinator.data) if coordinator is not None else None,
+        },
+    }
+
+
+def _serialize_value(value: Any) -> Any:
+    """Convert runtime models into JSON-serializable diagnostics data."""
+    if is_dataclass(value):
+        return {
+            field.name: _serialize_value(getattr(value, field.name))
+            for field in fields(value)
+        }
+
+    if isinstance(value, Enum):
+        return value.value
+
+    if isinstance(value, datetime):
+        return value.isoformat()
+
+    if isinstance(value, dict):
+        return {
+            str(key): _serialize_value(item)
+            for key, item in value.items()
+        }
+
+    if isinstance(value, (list, tuple, set)):
+        return [_serialize_value(item) for item in value]
+
+    return value

--- a/tests/components/multi_zone_heating/test_diagnostics.py
+++ b/tests/components/multi_zone_heating/test_diagnostics.py
@@ -1,0 +1,91 @@
+"""Tests for multi_zone_heating diagnostics export."""
+
+from __future__ import annotations
+
+from homeassistant.const import STATE_OFF
+from homeassistant.core import ServiceCall
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from custom_components.multi_zone_heating.const import DOMAIN
+from custom_components.multi_zone_heating.diagnostics import (
+    async_get_config_entry_diagnostics,
+)
+
+
+def _build_config_entry() -> MockConfigEntry:
+    """Create a representative config entry for diagnostics tests."""
+    return MockConfigEntry(
+        domain=DOMAIN,
+        title="Multi-Zone Heating",
+        data={
+            "main_relay_entity_id": "switch.boiler",
+            "flow_sensor_entity_id": "sensor.system_flow",
+            "flow_detection_threshold": 1.5,
+            "missing_flow_timeout_seconds": 60,
+            "default_hysteresis": 0.3,
+            "relay_off_delay_seconds": 0,
+            "zones": [
+                {
+                    "name": "Living Room",
+                    "enabled": True,
+                    "control_type": "switch",
+                    "target_source": "input_number",
+                    "target_entity_id": "input_number.living_room_target",
+                    "local_groups": [
+                        {
+                            "name": "Radiator",
+                            "control_type": "switch",
+                            "actuator_entity_ids": ["switch.radiator"],
+                            "sensor_entity_ids": ["sensor.living_room_temperature"],
+                            "aggregation_mode": "average",
+                        }
+                    ],
+                }
+            ],
+        },
+        version=1,
+    )
+
+
+def _register_recording_switch_services(hass) -> None:
+    """Register fake switch services needed during coordinator refresh."""
+
+    async def _record_turn_on(call: ServiceCall) -> None:
+        hass.states.async_set(call.data["entity_id"], "on")
+
+    async def _record_turn_off(call: ServiceCall) -> None:
+        hass.states.async_set(call.data["entity_id"], STATE_OFF)
+
+    hass.services.async_register("switch", "turn_on", _record_turn_on)
+    hass.services.async_register("switch", "turn_off", _record_turn_off)
+
+
+async def test_config_entry_diagnostics_include_config_and_runtime_state(hass) -> None:
+    """Diagnostics should expose both typed config and live runtime state."""
+    hass.states.async_set("sensor.living_room_temperature", "19.0")
+    hass.states.async_set("input_number.living_room_target", "20.0")
+    hass.states.async_set("sensor.system_flow", "0.0")
+    hass.states.async_set("switch.radiator", STATE_OFF)
+    hass.states.async_set("switch.boiler", STATE_OFF)
+    _register_recording_switch_services(hass)
+
+    entry = _build_config_entry()
+    entry.add_to_hass(hass)
+
+    assert await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    diagnostics = await async_get_config_entry_diagnostics(hass, entry)
+
+    assert diagnostics["config_entry"]["version"] == 1
+    assert diagnostics["config"]["main_relay_entity_id"] == "switch.boiler"
+    assert diagnostics["config"]["zones"][0]["control_type"] == "switch"
+    assert diagnostics["runtime"]["loaded"] is True
+    assert diagnostics["runtime"]["global_force_off"] is False
+    assert diagnostics["runtime"]["snapshot"]["flow_detected"] is False
+    assert diagnostics["runtime"]["snapshot"]["relay_runtime_state"]["is_on"] is True
+    assert diagnostics["runtime"]["snapshot"]["zone_evaluations"][0]["name"] == "Living Room"
+    assert diagnostics["runtime"]["snapshot"]["zone_evaluations"][0]["local_groups"][0]["name"] == "Radiator"
+    assert diagnostics["runtime"]["snapshot"]["target_temperatures"] == {
+        "Living Room": 20.0,
+    }


### PR DESCRIPTION
## Review-only PR
This PR exists only to allow code review of the issue #13 change after PR #22 was merged early.

Please do not merge this PR.
The underlying change is already on `main` via PR #22.

## Scope under review
- add `diagnostics.py` to export structured config-entry and live runtime state for `multi_zone_heating`
- add a diagnostics test that validates the exported config and coordinator snapshot
- update the GitHub Actions test workflow to run under coverage and print a coverage report in CI output

## Original validation
- `PYTHONPATH=. .venv/bin/pytest -q tests/components/multi_zone_heating/test_diagnostics.py tests/components/multi_zone_heating/test_init.py tests/components/multi_zone_heating/test_control_logic.py tests/components/multi_zone_heating/test_coordinator.py tests/components/multi_zone_heating/test_entities.py tests/components/multi_zone_heating/test_config_flow.py`
- `PYTHONPATH=. .venv/bin/python -m coverage run -m pytest -q tests/components/multi_zone_heating/test_diagnostics.py tests/components/multi_zone_heating/test_init.py tests/components/multi_zone_heating/test_control_logic.py tests/components/multi_zone_heating/test_coordinator.py tests/components/multi_zone_heating/test_entities.py tests/components/multi_zone_heating/test_config_flow.py`
- `PYTHONPATH=. .venv/bin/python -m coverage report -m custom_components/multi_zone_heating/*.py`
