### PR TITLE
[codex] Support input_boolean global relay

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Version `0.1.0` is the first working implementation. It supports UI-based setup,
 
 - One Home Assistant config entry that manages the full heating system
 - Multiple zones with independent demand evaluation
-- A shared main relay that follows aggregate demand
+- A shared main relay that follows aggregate demand and may be backed by a `switch` or `input_boolean`
 - Zone control via `climate`, `switch`, or `number` actuators
 - Zone targets sourced from either a `climate` entity or a `number`/`input_number`
 - Temperature aggregation using `average`, `minimum`, or `primary` sensor selection

--- a/custom_components/multi_zone_heating/config_flow.py
+++ b/custom_components/multi_zone_heating/config_flow.py
@@ -78,7 +78,7 @@ class _MultiZoneHeatingFlowBase:
             {
                 vol.Optional(CONF_NAME, default=DEFAULT_TITLE): str,
                 vol.Required(CONF_MAIN_RELAY_ENTITY_ID): selector.EntitySelector(
-                    selector.EntitySelectorConfig(domain=["switch"])
+                    selector.EntitySelectorConfig(domain=["switch", "input_boolean"])
                 ),
                 vol.Optional(CONF_FLOW_SENSOR_ENTITY_ID): selector.EntitySelector(
                     selector.EntitySelectorConfig(domain=["sensor", "number", "input_number"])

--- a/custom_components/multi_zone_heating/coordinator.py
+++ b/custom_components/multi_zone_heating/coordinator.py
@@ -237,7 +237,7 @@ class MultiZoneHeatingCoordinator(DataUpdateCoordinator[RuntimeSnapshot]):
         flow_value = snapshot.flow_value
 
         previous_relay_is_on = self._relay_runtime_state.is_on
-        current_relay_is_on = self._read_switch_state(self.config.main_relay_entity_id)
+        current_relay_is_on = self._read_toggle_state(self.config.main_relay_entity_id)
         pending_relay_command = self._last_commanded_switch_states.get(
             self.config.main_relay_entity_id or ""
         )
@@ -561,7 +561,7 @@ class MultiZoneHeatingCoordinator(DataUpdateCoordinator[RuntimeSnapshot]):
     async def _async_dispatch_switch_group(self, group: LocalControlGroup, demand: bool) -> None:
         """Turn switch actuators on or off for one local group."""
         for entity_id in group.actuator_entity_ids:
-            await self._async_dispatch_switch(entity_id, demand)
+            await self._async_dispatch_toggle_entity(entity_id, demand)
 
     async def _async_dispatch_number_group(self, group: LocalControlGroup, demand: bool) -> None:
         """Write active or inactive values for number-based actuators."""
@@ -603,14 +603,14 @@ class MultiZoneHeatingCoordinator(DataUpdateCoordinator[RuntimeSnapshot]):
             return
 
         if relay_decision.should_turn_on:
-            await self._async_dispatch_switch(self.config.main_relay_entity_id, True)
+            await self._async_dispatch_toggle_entity(self.config.main_relay_entity_id, True)
             self._relay_runtime_state.is_on = True
             self._relay_runtime_state.last_on_at = now
             self._relay_runtime_state.off_requested_at = None
             return
 
         if relay_decision.should_turn_off:
-            await self._async_dispatch_switch(self.config.main_relay_entity_id, False)
+            await self._async_dispatch_toggle_entity(self.config.main_relay_entity_id, False)
             self._relay_runtime_state.is_on = False
             self._relay_runtime_state.last_off_at = now
             self._relay_runtime_state.off_requested_at = None
@@ -618,12 +618,12 @@ class MultiZoneHeatingCoordinator(DataUpdateCoordinator[RuntimeSnapshot]):
 
         self._relay_runtime_state.off_requested_at = relay_decision.off_requested_at
 
-    async def _async_dispatch_switch(self, entity_id: str, desired_on: bool) -> None:
-        """Turn a switch entity on or off only when required."""
+    async def _async_dispatch_toggle_entity(self, entity_id: str, desired_on: bool) -> None:
+        """Turn an on/off entity on or off only when required."""
         if not self._entity_is_available(entity_id):
             return
 
-        current_state = self._read_switch_state(entity_id)
+        current_state = self._read_toggle_state(entity_id)
         if current_state is desired_on:
             self._last_commanded_switch_states.pop(entity_id, None)
             return
@@ -729,7 +729,7 @@ class MultiZoneHeatingCoordinator(DataUpdateCoordinator[RuntimeSnapshot]):
 
         return supported_modes
 
-    def _read_switch_state(self, entity_id: str | None) -> bool | None:
+    def _read_toggle_state(self, entity_id: str | None) -> bool | None:
         """Read an on/off state from Home Assistant."""
         if entity_id is None:
             return None

--- a/docs/integration-design.md
+++ b/docs/integration-design.md
@@ -468,7 +468,7 @@ These are the main choices we should resolve before implementation:
 
 To keep the first implementation manageable:
 
-- Support one main relay switch
+- Support one main relay `switch` or `input_boolean`
 - Support one optional numeric flow meter and configurable detection threshold
 - Support multiple zones
 - Support one or more temperature sensors per zone

--- a/docs/issues/ISSUE-011-input-boolean-global-relay.md
+++ b/docs/issues/ISSUE-011-input-boolean-global-relay.md
@@ -1,0 +1,38 @@
+# ISSUE-011 Input Boolean Global Relay
+
+## Goal
+
+Allow the global relay to be configured with an `input_boolean` entity in addition to a `switch`.
+
+## Scope
+
+- Accept `input_boolean` entities in the global relay config-flow selector
+- Preserve relay runtime behavior for both `switch` and `input_boolean` domains
+- Document the supported global relay entity types
+- Add regression coverage for the new relay domain
+
+## Why
+
+Some Home Assistant installations expose the shared boiler enable control as an `input_boolean` helper instead of a native `switch`. The integration should support either on/off entity type for the global relay path.
+
+## Related Stories
+
+- US-013
+- US-014
+
+## Acceptance Criteria
+
+- The initial config flow accepts either `switch.*` or `input_boolean.*` for the main relay entity
+- A configured `input_boolean` global relay receives `turn_on` and `turn_off` service calls when demand changes
+- Existing `switch`-based global relay behavior remains unchanged
+- User-facing documentation states that the main relay may be a `switch` or `input_boolean`
+
+## Dependencies
+
+- ISSUE-002
+- ISSUE-004
+
+## Out Of Scope
+
+- Supporting additional relay-like domains
+- Changing zone actuator support beyond the existing behavior

--- a/tests/components/multi_zone_heating/test_config_flow.py
+++ b/tests/components/multi_zone_heating/test_config_flow.py
@@ -719,6 +719,50 @@ async def test_options_flow_updates_globals_zone_and_local_group(hass) -> None:
     )
 
 
+async def test_options_flow_updates_globals_with_input_boolean_relay(hass) -> None:
+    """Options flow should accept input_boolean helpers for the global relay."""
+    config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        title="Original Heating",
+        data=_existing_config(),
+        version=1,
+    )
+    config_entry.add_to_hass(hass)
+
+    result = await hass.config_entries.options.async_init(config_entry.entry_id)
+    assert result["type"] is data_entry_flow.FlowResultType.FORM
+    assert result["step_id"] == "init"
+
+    result = await hass.config_entries.options.async_configure(
+        result["flow_id"],
+        {CONF_ACTION: ACTION_EDIT_GLOBALS},
+    )
+    assert result["step_id"] == "edit_globals"
+
+    result = await hass.config_entries.options.async_configure(
+        result["flow_id"],
+        {
+            CONF_NAME: "Edited Heating",
+            CONF_MAIN_RELAY_ENTITY_ID: "input_boolean.updated_boiler_enable",
+            CONF_MISSING_FLOW_TIMEOUT_SECONDS: 60,
+            CONF_DEFAULT_HYSTERESIS: 0.3,
+            CONF_MIN_RELAY_ON_TIME_SECONDS: 0,
+            CONF_MIN_RELAY_OFF_TIME_SECONDS: 0,
+            CONF_RELAY_OFF_DELAY_SECONDS: 0,
+            CONF_FROST_PROTECTION_MIN_TEMP: 7.0,
+        },
+    )
+    assert result["step_id"] == "init"
+
+    result = await hass.config_entries.options.async_configure(
+        result["flow_id"],
+        {CONF_ACTION: ACTION_DONE},
+    )
+
+    assert result["type"] is data_entry_flow.FlowResultType.CREATE_ENTRY
+    assert result["data"][CONF_MAIN_RELAY_ENTITY_ID] == "input_boolean.updated_boiler_enable"
+
+
 async def test_options_flow_can_add_and_remove_zones_and_local_groups(hass) -> None:
     """Options flow should support adding and removing zones and groups."""
     config_entry = MockConfigEntry(

--- a/tests/components/multi_zone_heating/test_config_flow.py
+++ b/tests/components/multi_zone_heating/test_config_flow.py
@@ -73,7 +73,6 @@ async def _start_basic_flow(hass, *, name: str = DEFAULT_TITLE):
         },
     )
 
-
 def _existing_config() -> dict[str, object]:
     """Build a representative config-entry payload for options-flow tests."""
     return {
@@ -111,6 +110,32 @@ def _existing_config() -> dict[str, object]:
             }
         ],
     }
+
+
+async def test_user_flow_accepts_input_boolean_for_main_relay(hass) -> None:
+    """The global relay selector should accept input_boolean helpers."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+
+    assert result["type"] is data_entry_flow.FlowResultType.FORM
+    assert result["step_id"] == "user"
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {
+            CONF_NAME: "Helper Relay",
+            CONF_MAIN_RELAY_ENTITY_ID: "input_boolean.boiler_enable",
+            CONF_MISSING_FLOW_TIMEOUT_SECONDS: 60,
+            CONF_DEFAULT_HYSTERESIS: 0.3,
+            CONF_MIN_RELAY_ON_TIME_SECONDS: 0,
+            CONF_MIN_RELAY_OFF_TIME_SECONDS: 0,
+            CONF_RELAY_OFF_DELAY_SECONDS: 0,
+        },
+    )
+
+    assert result["type"] is data_entry_flow.FlowResultType.FORM
+    assert result["step_id"] == "zone"
 
 
 async def test_user_flow_creates_entry_for_climate_zone(hass) -> None:

--- a/tests/components/multi_zone_heating/test_coordinator.py
+++ b/tests/components/multi_zone_heating/test_coordinator.py
@@ -202,8 +202,8 @@ async def test_coordinator_dispatches_input_boolean_global_relay(hass) -> None:
     hass.states.async_set("switch.radiator", "off")
     hass.states.async_set("input_boolean.boiler_enable", "off")
 
-    _register_recording_switch_services(hass)
-    calls = _register_recording_toggle_services(hass, "input_boolean")
+    switch_calls = _register_recording_switch_services(hass)
+    relay_calls = _register_recording_toggle_services(hass, "input_boolean")
 
     config = _build_switch_config()
     config.main_relay_entity_id = "input_boolean.boiler_enable"
@@ -212,16 +212,20 @@ async def test_coordinator_dispatches_input_boolean_global_relay(hass) -> None:
     await coordinator.async_start()
     await hass.async_block_till_done()
 
-    assert calls == [("turn_on", {"entity_id": "input_boolean.boiler_enable"})]
+    assert switch_calls == [("turn_on", {"entity_id": "switch.radiator"})]
+    assert relay_calls == [("turn_on", {"entity_id": "input_boolean.boiler_enable"})]
 
     hass.states.async_set("sensor.living_room_temperature", "20.5")
+    hass.states.async_set("switch.radiator", "on")
     hass.states.async_set("input_boolean.boiler_enable", "on")
-    calls.clear()
+    switch_calls.clear()
+    relay_calls.clear()
 
     await coordinator.async_request_refresh()
     await hass.async_block_till_done()
 
-    assert calls == [("turn_off", {"entity_id": "input_boolean.boiler_enable"})]
+    assert switch_calls == [("turn_off", {"entity_id": "switch.radiator"})]
+    assert relay_calls == [("turn_off", {"entity_id": "input_boolean.boiler_enable"})]
     await coordinator.async_stop()
 
 

--- a/tests/components/multi_zone_heating/test_coordinator.py
+++ b/tests/components/multi_zone_heating/test_coordinator.py
@@ -66,6 +66,13 @@ def _build_flow_warning_config(*, missing_flow_timeout_seconds: int) -> Integrat
 
 def _register_recording_switch_services(hass) -> list[tuple[str, dict[str, str]]]:
     """Register fake switch services and record each invocation."""
+    return _register_recording_toggle_services(hass, "switch")
+
+
+def _register_recording_toggle_services(
+    hass, domain: str
+) -> list[tuple[str, dict[str, str]]]:
+    """Register fake on/off services and record each invocation."""
     calls: list[tuple[str, dict[str, str]]] = []
 
     async def _record_turn_on(call: ServiceCall) -> None:
@@ -74,8 +81,8 @@ def _register_recording_switch_services(hass) -> list[tuple[str, dict[str, str]]
     async def _record_turn_off(call: ServiceCall) -> None:
         calls.append(("turn_off", dict(call.data)))
 
-    hass.services.async_register("switch", "turn_on", _record_turn_on)
-    hass.services.async_register("switch", "turn_off", _record_turn_off)
+    hass.services.async_register(domain, "turn_on", _record_turn_on)
+    hass.services.async_register(domain, "turn_off", _record_turn_off)
     return calls
 
 
@@ -185,6 +192,36 @@ async def test_coordinator_rechecks_relay_after_off_delay(hass, monkeypatch) -> 
     await hass.async_block_till_done()
 
     assert calls == [("turn_off", {"entity_id": "switch.boiler"})]
+    await coordinator.async_stop()
+
+
+async def test_coordinator_dispatches_input_boolean_global_relay(hass) -> None:
+    """The main relay may be backed by an input_boolean helper."""
+    hass.states.async_set("sensor.living_room_temperature", "19.0")
+    hass.states.async_set("input_number.living_room_target", "20.0")
+    hass.states.async_set("switch.radiator", "off")
+    hass.states.async_set("input_boolean.boiler_enable", "off")
+
+    _register_recording_switch_services(hass)
+    calls = _register_recording_toggle_services(hass, "input_boolean")
+
+    config = _build_switch_config()
+    config.main_relay_entity_id = "input_boolean.boiler_enable"
+
+    coordinator = MultiZoneHeatingCoordinator(hass, config)
+    await coordinator.async_start()
+    await hass.async_block_till_done()
+
+    assert calls == [("turn_on", {"entity_id": "input_boolean.boiler_enable"})]
+
+    hass.states.async_set("sensor.living_room_temperature", "20.5")
+    hass.states.async_set("input_boolean.boiler_enable", "on")
+    calls.clear()
+
+    await coordinator.async_request_refresh()
+    await hass.async_block_till_done()
+
+    assert calls == [("turn_off", {"entity_id": "input_boolean.boiler_enable"})]
     await coordinator.async_stop()
 
 


### PR DESCRIPTION
## Summary
Support `input_boolean` as a valid global relay entity in addition to `switch`.

## Why
Some Home Assistant setups expose the shared boiler enable control as an `input_boolean` helper instead of a native `switch`. This change lets the integration accept either on/off entity type for the main relay path.

## Changes
- add `docs/issues/ISSUE-011-input-boolean-global-relay.md`
- allow `input_boolean` in the global relay config-flow selector
- add regression coverage for config flow and coordinator dispatch using an `input_boolean` relay
- update design/readme wording to reflect the supported relay types

## Validation
- `PYTHONPATH=. .venv/bin/pytest tests/components/multi_zone_heating/test_config_flow.py -q`
- `PYTHONPATH=. .venv/bin/pytest tests/components/multi_zone_heating/test_coordinator.py -q`

## Issue
Closes #25