### PR TITLE
[codex] Update zone virtual climate design docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 `multi_zone_heating` is a custom Home Assistant integration for coordinating multiple heating zones behind a shared main relay.
 
-Version `0.2.0` is the current release. It supports UI-based setup, climate- and actuator-driven zones, a shared relay, optional flow diagnostics, and a small set of runtime control entities for overrides and operations.
+Version `0.2.0` is the current release. It supports UI-based setup, climate- and actuator-driven zones, a shared relay, optional flow diagnostics, and a small set of runtime control entities for master commands and operations.
 
 ## Current Capabilities
 
@@ -10,14 +10,14 @@ Version `0.2.0` is the current release. It supports UI-based setup, climate- and
 - Multiple zones with independent demand evaluation
 - A shared main relay that follows aggregate demand and may be backed by a `switch` or `input_boolean`
 - Zone control via `climate`, `switch`, or `number` actuators
-- Zone targets sourced from either a `climate` entity or a `number`/`input_number`
+- Integration-owned zone targets
 - Temperature aggregation using `average`, `minimum`, or `primary` sensor selection
 - Optional relay timing protections:
   - minimum relay on time
   - minimum relay off time
   - relay off delay
 - Optional flow monitoring with missing-flow warnings
-- System-wide override temperature and global force-off control
+- System climate target fan-out and global force-off control
 - Per-zone enable and disable control
 
 ## Documentation
@@ -42,14 +42,12 @@ Full setup and usage details are in the [installation and usage guide](docs/inst
 
 Once configured, the integration creates:
 
-- One system climate entity for global override control
+- One system climate entity for master target commands
 - One system demand binary sensor
 - One zone demand binary sensor per configured zone
 - One global force-off switch
 - One zone enabled switch per configured zone
 - One relay-state diagnostic sensor
-
-It also registers the `multi_zone_heating.clear_override` service.
 
 ## Development
 

--- a/custom_components/multi_zone_heating/__init__.py
+++ b/custom_components/multi_zone_heating/__init__.py
@@ -3,20 +3,63 @@
 from __future__ import annotations
 
 from copy import deepcopy
+import logging
 from typing import TYPE_CHECKING, TypeAlias
 
 from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import STATE_UNAVAILABLE, STATE_UNKNOWN
 from homeassistant.core import HomeAssistant, ServiceCall
 
-from .const import DOMAIN, PLATFORMS
+from .const import (
+    CONFIG_ENTRY_VERSION,
+    DOMAIN,
+    PLATFORMS,
+)
 from .models import RuntimeData
 from .coordinator import MultiZoneHeatingCoordinator, integration_config_from_dict
+from .target_temperature import initial_zone_target_temperature
 
 if TYPE_CHECKING:
     MultiZoneHeatingConfigEntry: TypeAlias = ConfigEntry[RuntimeData]
 else:
     # Older Home Assistant test targets expose ConfigEntry as a non-generic type.
     MultiZoneHeatingConfigEntry: TypeAlias = ConfigEntry
+
+_LOGGER = logging.getLogger(__name__)
+
+
+async def async_migrate_entry(
+    hass: HomeAssistant,
+    entry: MultiZoneHeatingConfigEntry,
+) -> bool:
+    """Migrate older config entries to the current schema."""
+    if entry.version >= CONFIG_ENTRY_VERSION:
+        return True
+
+    if entry.version != 1:
+        _LOGGER.error("Unsupported config entry version %s", entry.version)
+        return False
+
+    migrated_data = _migrate_payload(hass, dict(entry.data), fallback_payload=dict(entry.data))
+    if migrated_data is None:
+        return False
+
+    migrated_options = _migrate_payload(
+        hass,
+        dict(entry.options),
+        fallback_payload=dict(entry.data),
+    )
+    if migrated_options is None:
+        return False
+
+    hass.config_entries.async_update_entry(
+        entry,
+        data=migrated_data,
+        options=migrated_options,
+        version=CONFIG_ENTRY_VERSION,
+    )
+    _LOGGER.info("Migrated config entry %s to version %s", entry.entry_id, CONFIG_ENTRY_VERSION)
+    return True
 
 
 async def async_setup_entry(
@@ -82,3 +125,96 @@ async def _async_update_listener(
 ) -> None:
     """Reload the entry when options change so runtime state stays in sync."""
     await hass.config_entries.async_reload(entry.entry_id)
+
+
+def _migrate_payload(
+    hass: HomeAssistant,
+    payload: dict[str, object],
+    *,
+    fallback_payload: dict[str, object],
+) -> dict[str, object] | None:
+    """Migrate one config payload that may contain zone definitions."""
+    zones = payload.get("zones")
+    if not isinstance(zones, list):
+        return payload
+
+    migrated_payload = deepcopy(payload)
+    # Options may override only zone definitions and omit the global frost minimum,
+    # so keep the data payload as the fallback source for that shared setting.
+    global_frost = migrated_payload.get(
+        "frost_protection_min_temp",
+        fallback_payload.get("frost_protection_min_temp"),
+    )
+    migrated_zones = []
+    for zone_data in zones:
+        migrated_zone = _migrate_zone_data(
+            hass,
+            zone_data,
+            global_frost_protection_min_temp=global_frost,
+        )
+        if migrated_zone is None:
+            return None
+        migrated_zones.append(migrated_zone)
+
+    migrated_payload["zones"] = migrated_zones
+    return migrated_payload
+
+
+def _migrate_zone_data(
+    hass: HomeAssistant,
+    zone_data: object,
+    *,
+    global_frost_protection_min_temp: object | None,
+) -> dict[str, object] | None:
+    """Migrate one zone from external targets to an owned target value."""
+    if not isinstance(zone_data, dict):
+        return None
+
+    migrated_zone = deepcopy(zone_data)
+    if "target_temperature" in migrated_zone:
+        migrated_zone.pop("target_source", None)
+        migrated_zone.pop("target_entity_id", None)
+        return migrated_zone
+
+    target_entity_id = migrated_zone.get("target_entity_id")
+    zone_name = migrated_zone.get("name", "<unknown>")
+    target_temperature = _read_legacy_target_temperature(hass, target_entity_id)
+    if target_temperature is None:
+        _LOGGER.error(
+            "Cannot migrate zone %s because target entity %s has no usable current target state",
+            zone_name,
+            target_entity_id,
+        )
+        return None
+
+    migrated_zone["target_temperature"] = max(
+        target_temperature,
+        initial_zone_target_temperature(
+            global_frost_protection_min_temp,
+            migrated_zone.get("frost_protection_min_temp"),
+        ),
+    )
+    migrated_zone.pop("target_source", None)
+    migrated_zone.pop("target_entity_id", None)
+    return migrated_zone
+def _read_legacy_target_temperature(
+    hass: HomeAssistant,
+    target_entity_id: object | None,
+) -> float | None:
+    """Read the current target from an old external target entity."""
+    if not isinstance(target_entity_id, str):
+        return None
+
+    state = hass.states.get(target_entity_id)
+    if state is None or state.state in {STATE_UNKNOWN, STATE_UNAVAILABLE}:
+        return None
+
+    if target_entity_id.startswith("climate."):
+        value = state.attributes.get("temperature")
+    else:
+        value = state.state
+
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None

--- a/custom_components/multi_zone_heating/__init__.py
+++ b/custom_components/multi_zone_heating/__init__.py
@@ -8,7 +8,7 @@ from typing import TYPE_CHECKING, TypeAlias
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import STATE_UNAVAILABLE, STATE_UNKNOWN
-from homeassistant.core import HomeAssistant, ServiceCall
+from homeassistant.core import HomeAssistant
 
 from .const import (
     CONFIG_ENTRY_VERSION,
@@ -82,18 +82,6 @@ async def async_setup_entry(
     )
     domain_data[entry.entry_id] = entry.runtime_data
 
-    if not hass.services.has_service(DOMAIN, "clear_override"):
-
-        async def _async_handle_clear_override(_call: ServiceCall) -> None:
-            """Clear overrides across loaded integration entries."""
-            await _async_clear_overrides(hass)
-
-        hass.services.async_register(
-            DOMAIN,
-            "clear_override",
-            _async_handle_clear_override,
-        )
-
     await coordinator.async_start()
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
     return True
@@ -110,15 +98,7 @@ async def async_unload_entry(
         if coordinator is not None:
             await coordinator.async_stop()
         hass.data.get(DOMAIN, {}).pop(entry.entry_id, None)
-        if not hass.data.get(DOMAIN):
-            hass.services.async_remove(DOMAIN, "clear_override")
     return unloaded
-
-async def _async_clear_overrides(hass: HomeAssistant) -> None:
-    """Clear runtime overrides for all loaded entries."""
-    for runtime_data in hass.data.get(DOMAIN, {}).values():
-        if runtime_data.coordinator is not None:
-            await runtime_data.coordinator.async_clear_global_override()
 async def _async_update_listener(
     hass: HomeAssistant,
     entry: MultiZoneHeatingConfigEntry,
@@ -179,20 +159,22 @@ def _migrate_zone_data(
     target_entity_id = migrated_zone.get("target_entity_id")
     zone_name = migrated_zone.get("name", "<unknown>")
     target_temperature = _read_legacy_target_temperature(hass, target_entity_id)
+    fallback_target_temperature = initial_zone_target_temperature(
+        global_frost_protection_min_temp,
+        migrated_zone.get("frost_protection_min_temp"),
+    )
     if target_temperature is None:
-        _LOGGER.error(
-            "Cannot migrate zone %s because target entity %s has no usable current target state",
+        _LOGGER.warning(
+            "Migrating zone %s without a readable target from %s; using fallback target %s",
             zone_name,
             target_entity_id,
+            fallback_target_temperature,
         )
-        return None
+        target_temperature = fallback_target_temperature
 
     migrated_zone["target_temperature"] = max(
         target_temperature,
-        initial_zone_target_temperature(
-            global_frost_protection_min_temp,
-            migrated_zone.get("frost_protection_min_temp"),
-        ),
+        fallback_target_temperature,
     )
     migrated_zone.pop("target_source", None)
     migrated_zone.pop("target_entity_id", None)

--- a/custom_components/multi_zone_heating/climate.py
+++ b/custom_components/multi_zone_heating/climate.py
@@ -199,12 +199,18 @@ class MultiZoneHeatingZoneClimate(MultiZoneHeatingClimateBase):
     @property
     def hvac_action(self) -> HVACAction | None:
         """Return whether the zone is actively demanding heat."""
-        evaluation = self.coordinator.get_zone_evaluation(self._zone_name)
-        if evaluation is None:
+        data = self.coordinator.data
+        if data is None:
             return None
 
         zone = self.coordinator.get_zone_config(self._zone_name)
-        if zone is None or not zone.enabled:
+        evaluation = self.coordinator.get_zone_evaluation(self._zone_name)
+        if (
+            zone is None
+            or evaluation is None
+            or not zone.enabled
+            or data.global_force_off
+        ):
             return HVACAction.OFF
         return HVACAction.HEATING if evaluation.demand else HVACAction.IDLE
 

--- a/custom_components/multi_zone_heating/climate.py
+++ b/custom_components/multi_zone_heating/climate.py
@@ -17,6 +17,7 @@ from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from . import MultiZoneHeatingConfigEntry
 from .const import DOMAIN
+from .models import ControlType
 
 
 async def async_setup_entry(
@@ -25,13 +26,23 @@ async def async_setup_entry(
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up climate entities for a config entry."""
-    if entry.runtime_data.coordinator is None:
+    runtime_data = entry.runtime_data
+    coordinator = runtime_data.coordinator
+    if coordinator is None:
         return
-    async_add_entities([MultiZoneHeatingSystemClimate(entry)])
+    async_add_entities(
+        [
+            MultiZoneHeatingSystemClimate(entry),
+            *[
+                MultiZoneHeatingZoneClimate(entry, zone.name)
+                for zone in runtime_data.config.zones
+            ],
+        ]
+    )
 
 
-class MultiZoneHeatingSystemClimate(CoordinatorEntity, ClimateEntity):
-    """Top-level climate entity for system-wide override control."""
+class MultiZoneHeatingClimateBase(CoordinatorEntity, ClimateEntity):
+    """Base climate entity backed by the runtime coordinator."""
 
     _attr_has_entity_name = True
     _attr_hvac_modes = [HVACMode.HEAT, HVACMode.OFF]
@@ -43,8 +54,6 @@ class MultiZoneHeatingSystemClimate(CoordinatorEntity, ClimateEntity):
         """Initialize the climate entity."""
         super().__init__(entry.runtime_data.coordinator)
         self._entry = entry
-        self._attr_name = "System"
-        self._attr_unique_id = f"{entry.entry_id}_system_climate"
 
     @property
     def available(self) -> bool:
@@ -58,6 +67,16 @@ class MultiZoneHeatingSystemClimate(CoordinatorEntity, ClimateEntity):
             "identifiers": {(DOMAIN, self._entry.entry_id)},
             "name": self._entry.title,
         }
+
+
+class MultiZoneHeatingSystemClimate(MultiZoneHeatingClimateBase):
+    """Top-level climate entity for system-wide override control."""
+
+    def __init__(self, entry: MultiZoneHeatingConfigEntry) -> None:
+        """Initialize the climate entity."""
+        super().__init__(entry)
+        self._attr_name = "System"
+        self._attr_unique_id = f"{entry.entry_id}_system_climate"
 
     @property
     def hvac_mode(self) -> HVACMode | None:
@@ -156,3 +175,112 @@ class MultiZoneHeatingSystemClimate(CoordinatorEntity, ClimateEntity):
             return
 
         await self.coordinator.async_set_global_override(float(target_temperature))
+
+
+class MultiZoneHeatingZoneClimate(MultiZoneHeatingClimateBase):
+    """Virtual climate entity that owns one zone target temperature."""
+
+    def __init__(self, entry: MultiZoneHeatingConfigEntry, zone_name: str) -> None:
+        """Initialize the zone climate entity."""
+        super().__init__(entry)
+        self._zone_name = zone_name
+        self._attr_name = zone_name
+        self._attr_unique_id = f"{entry.entry_id}_{zone_name}_climate"
+
+    @property
+    def hvac_mode(self) -> HVACMode | None:
+        """Return whether the zone is enabled for heating."""
+        zone = self.coordinator.get_zone_config(self._zone_name)
+        if zone is None:
+            return None
+        return HVACMode.HEAT if zone.enabled else HVACMode.OFF
+
+    @property
+    def hvac_action(self) -> HVACAction | None:
+        """Return whether the zone is actively demanding heat."""
+        evaluation = self.coordinator.get_zone_evaluation(self._zone_name)
+        if evaluation is None:
+            return None
+
+        zone = self.coordinator.get_zone_config(self._zone_name)
+        if zone is None or not zone.enabled:
+            return HVACAction.OFF
+        return HVACAction.HEATING if evaluation.demand else HVACAction.IDLE
+
+    @property
+    def target_temperature(self) -> float | None:
+        """Return the owned target temperature for the zone."""
+        evaluation = self.coordinator.get_zone_evaluation(self._zone_name)
+        if evaluation is not None and evaluation.target_temperature is not None:
+            return evaluation.target_temperature
+
+        zone = self.coordinator.get_zone_config(self._zone_name)
+        if zone is None:
+            return None
+        return zone.target_temperature
+
+    @property
+    def current_temperature(self) -> float | None:
+        """Return the aggregated current temperature for the zone when available."""
+        evaluation = self.coordinator.get_zone_evaluation(self._zone_name)
+        if evaluation is None:
+            return None
+        return evaluation.current_temperature
+
+    @property
+    def min_temp(self) -> float:
+        """Return the minimum target temperature the entity should expose."""
+        zone = self.coordinator.get_zone_config(self._zone_name)
+        if zone is None:
+            return 5.0
+
+        minimums = [5.0]
+        if self.coordinator.config.frost_protection_min_temp is not None:
+            minimums.append(self.coordinator.config.frost_protection_min_temp)
+        if zone.frost_protection_min_temp is not None:
+            minimums.append(zone.frost_protection_min_temp)
+        return max(minimums)
+
+    @property
+    def max_temp(self) -> float:
+        """Return the maximum supported target temperature."""
+        return 35.0
+
+    @property
+    def extra_state_attributes(self) -> dict[str, Any]:
+        """Return diagnostic attributes for the virtual zone climate."""
+        zone = self.coordinator.get_zone_config(self._zone_name)
+        evaluation = self.coordinator.get_zone_evaluation(self._zone_name)
+        if zone is None or evaluation is None:
+            return {}
+
+        attributes: dict[str, Any] = {
+            "zone_name": self._zone_name,
+            "control_type": zone.control_type.value,
+            "aggregation_mode": zone.aggregation_mode.value,
+            "enabled": zone.enabled,
+            "demand": evaluation.demand,
+        }
+        if zone.primary_sensor_entity_id is not None:
+            attributes["primary_sensor_entity_id"] = zone.primary_sensor_entity_id
+        if zone.control_type is ControlType.CLIMATE:
+            attributes["sensor_entity_ids"] = zone.sensor_entity_ids
+        return attributes
+
+    async def async_set_hvac_mode(self, hvac_mode: HVACMode) -> None:
+        """Enable or disable the zone from the climate surface."""
+        await self.coordinator.async_set_zone_enabled(
+            self._zone_name,
+            hvac_mode == HVACMode.HEAT,
+        )
+
+    async def async_set_temperature(self, **kwargs: Any) -> None:
+        """Persist a new owned target temperature for the zone."""
+        target_temperature = kwargs.get("temperature")
+        if target_temperature is None:
+            return
+
+        await self.coordinator.async_set_zone_target_temperature(
+            self._zone_name,
+            float(target_temperature),
+        )

--- a/custom_components/multi_zone_heating/climate.py
+++ b/custom_components/multi_zone_heating/climate.py
@@ -70,7 +70,7 @@ class MultiZoneHeatingClimateBase(CoordinatorEntity, ClimateEntity):
 
 
 class MultiZoneHeatingSystemClimate(MultiZoneHeatingClimateBase):
-    """Top-level climate entity for system-wide override control."""
+    """Top-level climate entity for system-wide master commands."""
 
     def __init__(self, entry: MultiZoneHeatingConfigEntry) -> None:
         """Initialize the climate entity."""
@@ -97,13 +97,18 @@ class MultiZoneHeatingSystemClimate(MultiZoneHeatingClimateBase):
 
     @property
     def target_temperature(self) -> float | None:
-        """Return the displayed target temperature."""
+        """Return the shared zone target when the system is aligned."""
         data = self.coordinator.data
         if data is None:
             return None
-        if data.global_override is not None:
-            return data.global_override.target_temperature
-        return None
+        targets = {
+            evaluation.target_temperature
+            for evaluation in data.zone_evaluations
+            if evaluation.target_temperature is not None
+        }
+        if len(targets) != 1:
+            return None
+        return next(iter(targets))
 
     @property
     def current_temperature(self) -> float | None:
@@ -127,15 +132,13 @@ class MultiZoneHeatingSystemClimate(MultiZoneHeatingClimateBase):
     @property
     def min_temp(self) -> float:
         """Return the minimum target temperature the entity should expose."""
-        config_minimums = []
+        config_minimums = [5.0]
         if self.coordinator.config.frost_protection_min_temp is not None:
             config_minimums.append(self.coordinator.config.frost_protection_min_temp)
-        config_minimums.extend(
-            zone.frost_protection_min_temp
-            for zone in self.coordinator.config.zones
-            if zone.frost_protection_min_temp is not None
-        )
-        return min(config_minimums, default=5.0)
+        for zone in self.coordinator.config.zones:
+            if zone.frost_protection_min_temp is not None:
+                config_minimums.append(zone.frost_protection_min_temp)
+        return max(config_minimums)
 
     @property
     def max_temp(self) -> float:
@@ -144,23 +147,19 @@ class MultiZoneHeatingSystemClimate(MultiZoneHeatingClimateBase):
 
     @property
     def extra_state_attributes(self) -> dict[str, Any]:
-        """Return system override and demand attributes."""
+        """Return system summary attributes rooted in zone state."""
         data = self.coordinator.data
         if data is None:
             return {}
 
-        override_target_temperature = None
-        override_active = False
-        if data.global_override is not None:
-            override_active = data.global_override.active
-            override_target_temperature = data.global_override.target_temperature
-
         return {
-            "override_active": override_active,
-            "override_target_temperature": override_target_temperature,
             "zones_calling_for_heat": [
                 evaluation.name for evaluation in data.zone_evaluations if evaluation.demand
             ],
+            "zone_target_temperatures": {
+                evaluation.name: evaluation.target_temperature
+                for evaluation in data.zone_evaluations
+            },
             "global_force_off": data.global_force_off,
         }
 
@@ -169,12 +168,14 @@ class MultiZoneHeatingSystemClimate(MultiZoneHeatingClimateBase):
         await self.coordinator.async_set_global_force_off(hvac_mode == HVACMode.OFF)
 
     async def async_set_temperature(self, **kwargs: Any) -> None:
-        """Set the global override target temperature."""
+        """Fan a master target change out to every zone climate."""
         target_temperature = kwargs.get("temperature")
         if target_temperature is None:
             return
 
-        await self.coordinator.async_set_global_override(float(target_temperature))
+        await self.coordinator.async_set_all_zone_target_temperatures(
+            float(target_temperature)
+        )
 
 
 class MultiZoneHeatingZoneClimate(MultiZoneHeatingClimateBase):

--- a/custom_components/multi_zone_heating/config_flow.py
+++ b/custom_components/multi_zone_heating/config_flow.py
@@ -11,8 +11,9 @@ from homeassistant.const import CONF_NAME
 from homeassistant.core import callback
 from homeassistant.helpers import selector
 
-from .const import DEFAULT_TITLE, DOMAIN
-from .models import AggregationMode, ControlType, NumberSemanticType, TargetSourceType
+from .const import DEFAULT_TITLE, CONFIG_ENTRY_VERSION, DOMAIN
+from .models import AggregationMode, ControlType, NumberSemanticType
+from .target_temperature import initial_zone_target_temperature
 
 CONF_ACTION = "action"
 CONF_ACTIVE_VALUE = "active_value"
@@ -37,8 +38,7 @@ CONF_NUMBER_SEMANTIC_TYPE = "number_semantic_type"
 CONF_PRIMARY_SENSOR_ENTITY_ID = "primary_sensor_entity_id"
 CONF_RELAY_OFF_DELAY_SECONDS = "relay_off_delay_seconds"
 CONF_SENSOR_ENTITY_IDS = "sensor_entity_ids"
-CONF_TARGET_ENTITY_ID = "target_entity_id"
-CONF_TARGET_SOURCE = "target_source"
+CONF_TARGET_TEMPERATURE = "target_temperature"
 CONF_ZONE = "zone"
 CONF_ZONES = "zones"
 
@@ -139,22 +139,6 @@ class _MultiZoneHeatingFlowBase:
                             for item in ControlType
                         ],
                         mode="dropdown",
-                    )
-                ),
-                vol.Required(
-                    CONF_TARGET_SOURCE, default=TargetSourceType.CLIMATE
-                ): selector.SelectSelector(
-                    selector.SelectSelectorConfig(
-                        options=[
-                            {"value": item.value, "label": item.value.replace("_", " ").title()}
-                            for item in TargetSourceType
-                        ],
-                        mode="dropdown",
-                    )
-                ),
-                vol.Required(CONF_TARGET_ENTITY_ID): selector.EntitySelector(
-                    selector.EntitySelectorConfig(
-                        domain=["climate", "input_number", "number"]
                     )
                 ),
                 vol.Optional(CONF_FROST_PROTECTION_MIN_TEMP): selector.NumberSelector(
@@ -336,20 +320,6 @@ class _MultiZoneHeatingFlowBase:
         if not name:
             return {"base": "zone_name_required"}
 
-        target_source = user_input[CONF_TARGET_SOURCE]
-        target_entity_id = str(user_input[CONF_TARGET_ENTITY_ID])
-
-        if target_source == TargetSourceType.CLIMATE and not target_entity_id.startswith(
-            "climate."
-        ):
-            return {"base": "target_entity_domain_mismatch"}
-
-        if target_source == TargetSourceType.INPUT_NUMBER and not (
-            target_entity_id.startswith("input_number.")
-            or target_entity_id.startswith("number.")
-        ):
-            return {"base": "target_entity_domain_mismatch"}
-
         return {}
 
     def _validate_climate_zone_details(
@@ -423,16 +393,29 @@ class _MultiZoneHeatingFlowBase:
 
     def _build_pending_zone(self, user_input: dict[str, object]) -> None:
         """Store the shared zone fields that apply to all control types."""
+        zone_frost_protection = user_input.get(CONF_FROST_PROTECTION_MIN_TEMP)
         self._pending_zone = {
             CONF_NAME: str(user_input[CONF_NAME]).strip(),
             CONF_ENABLED: user_input[CONF_ENABLED],
             CONF_CONTROL_TYPE: user_input[CONF_CONTROL_TYPE],
-            CONF_TARGET_SOURCE: user_input[CONF_TARGET_SOURCE],
-            CONF_TARGET_ENTITY_ID: user_input[CONF_TARGET_ENTITY_ID],
+            CONF_TARGET_TEMPERATURE: initial_zone_target_temperature(
+                self._config.get(CONF_FROST_PROTECTION_MIN_TEMP),
+                zone_frost_protection
+            ),
             CONF_FROST_PROTECTION_MIN_TEMP: user_input.get(
                 CONF_FROST_PROTECTION_MIN_TEMP
             ),
         }
+
+        if self._editing_zone_index is not None:
+            existing_zone = self._zones()[self._editing_zone_index]
+            self._pending_zone[CONF_TARGET_TEMPERATURE] = existing_zone.get(
+                CONF_TARGET_TEMPERATURE,
+                initial_zone_target_temperature(
+                    self._config.get(CONF_FROST_PROTECTION_MIN_TEMP),
+                    zone_frost_protection,
+                ),
+            )
 
     def _build_climate_zone(self, user_input: dict[str, object]) -> dict[str, object]:
         """Build a complete climate-zone config from pending and detail input."""
@@ -552,8 +535,6 @@ class _MultiZoneHeatingFlowBase:
             CONF_NAME: zone[CONF_NAME],
             CONF_ENABLED: zone.get(CONF_ENABLED, True),
             CONF_CONTROL_TYPE: zone[CONF_CONTROL_TYPE],
-            CONF_TARGET_SOURCE: zone[CONF_TARGET_SOURCE],
-            CONF_TARGET_ENTITY_ID: zone[CONF_TARGET_ENTITY_ID],
             CONF_FROST_PROTECTION_MIN_TEMP: zone.get(CONF_FROST_PROTECTION_MIN_TEMP),
         }
 
@@ -594,7 +575,7 @@ class _MultiZoneHeatingFlowBase:
 class MultiZoneHeatingConfigFlow(_MultiZoneHeatingFlowBase, ConfigFlow, domain=DOMAIN):
     """Config flow for setting up a multi-zone heating system."""
 
-    VERSION = 1
+    VERSION = CONFIG_ENTRY_VERSION
 
     def __init__(self) -> None:
         """Initialize the config flow."""

--- a/custom_components/multi_zone_heating/const.py
+++ b/custom_components/multi_zone_heating/const.py
@@ -7,6 +7,8 @@ from homeassistant.const import Platform
 DOMAIN = "multi_zone_heating"
 NAME = "Multi-Zone Heating"
 DEFAULT_TITLE = NAME
+CONFIG_ENTRY_VERSION = 2
+DEFAULT_ZONE_TARGET_TEMPERATURE = 20.0
 
 PLATFORMS: tuple[Platform, ...] = (
     Platform.BINARY_SENSOR,

--- a/custom_components/multi_zone_heating/control_logic.py
+++ b/custom_components/multi_zone_heating/control_logic.py
@@ -8,7 +8,6 @@ from datetime import datetime, timedelta
 from .models import (
     AggregationMode,
     FlowWarningDecision,
-    GlobalOverride,
     LocalControlGroup,
     LocalControlGroupEvaluation,
     RelayDecision,
@@ -67,16 +66,11 @@ def resolve_frost_protection_minimum(
 def resolve_effective_target_temperature(
     zone_target_temperature: float | None,
     *,
-    global_override: GlobalOverride | None = None,
     zone_frost_protection_min_temp: float | None = None,
     global_frost_protection_min_temp: float | None = None,
 ) -> float | None:
-    """Resolve override and frost rules into one effective target."""
-    base_target = zone_target_temperature
-    if global_override is not None and global_override.active:
-        base_target = global_override.target_temperature
-
-    if base_target is None:
+    """Resolve frost rules into one effective target."""
+    if zone_target_temperature is None:
         return None
 
     frost_minimum = resolve_frost_protection_minimum(
@@ -84,9 +78,9 @@ def resolve_effective_target_temperature(
         global_frost_protection_min_temp,
     )
     if frost_minimum is None:
-        return base_target
+        return zone_target_temperature
 
-    return max(base_target, frost_minimum)
+    return max(zone_target_temperature, frost_minimum)
 
 
 def evaluate_hysteresis_demand(
@@ -117,7 +111,6 @@ def evaluate_local_control_group(
     available_actuator_entity_ids: Collection[str] | None = None,
     previous_demand: bool,
     hysteresis: float,
-    global_override: GlobalOverride | None = None,
     zone_frost_protection_min_temp: float | None = None,
     global_frost_protection_min_temp: float | None = None,
 ) -> LocalControlGroupEvaluation:
@@ -135,7 +128,6 @@ def evaluate_local_control_group(
     )
     effective_target_temperature = resolve_effective_target_temperature(
         zone_target_temperature,
-        global_override=global_override,
         zone_frost_protection_min_temp=zone_frost_protection_min_temp,
         global_frost_protection_min_temp=global_frost_protection_min_temp,
     )
@@ -169,13 +161,11 @@ def evaluate_zone(
     previous_demand: bool,
     previous_group_demands: Mapping[str, bool] | None = None,
     hysteresis: float,
-    global_override: GlobalOverride | None = None,
     global_frost_protection_min_temp: float | None = None,
 ) -> ZoneEvaluation:
     """Evaluate the demand state for a zone."""
     effective_target_temperature = resolve_effective_target_temperature(
         zone_target_temperature,
-        global_override=global_override,
         zone_frost_protection_min_temp=zone.frost_protection_min_temp,
         global_frost_protection_min_temp=global_frost_protection_min_temp,
     )
@@ -200,7 +190,6 @@ def evaluate_zone(
                 available_actuator_entity_ids=available_actuator_entity_ids,
                 previous_demand=group_demands.get(group.name, False),
                 hysteresis=hysteresis,
-                global_override=global_override,
                 zone_frost_protection_min_temp=zone.frost_protection_min_temp,
                 global_frost_protection_min_temp=global_frost_protection_min_temp,
             )

--- a/custom_components/multi_zone_heating/coordinator.py
+++ b/custom_components/multi_zone_heating/coordinator.py
@@ -34,7 +34,6 @@ from .control_logic import (
 from .models import (
     AggregationMode,
     ControlType,
-    GlobalOverride,
     IntegrationConfig,
     LocalControlGroup,
     NumberSemanticType,
@@ -67,10 +66,11 @@ def integration_config_from_dict(data: Mapping[str, Any]) -> IntegrationConfig:
 
 def _zone_from_dict(data: Mapping[str, Any]) -> ZoneConfig:
     """Build a typed zone config from config-entry data."""
+    target_temperature = _as_float(data.get("target_temperature"))
     return ZoneConfig(
         name=str(data["name"]),
         control_type=ControlType(data["control_type"]),
-        target_temperature=_as_float(data.get("target_temperature")) or 20.0,
+        target_temperature=target_temperature if target_temperature is not None else 20.0,
         sensor_entity_ids=list(data.get("sensor_entity_ids", [])),
         climate_entity_ids=list(data.get("climate_entity_ids", [])),
         climate_off_fallback_temperature=_as_float(
@@ -155,7 +155,6 @@ class MultiZoneHeatingCoordinator(DataUpdateCoordinator[RuntimeSnapshot]):
         self._last_commanded_climate_hvac_modes: dict[str, HVACMode] = {}
         self._last_observed_climate_hvac_modes: dict[str, HVACMode] = {}
         self._relay_runtime_state = RelayRuntimeState(is_on=False)
-        self._global_override: GlobalOverride | None = None
         self._global_force_off = False
 
     async def async_start(self) -> None:
@@ -207,11 +206,35 @@ class MultiZoneHeatingCoordinator(DataUpdateCoordinator[RuntimeSnapshot]):
         if zone is None:
             return
 
+        target_temperature = self._clamp_zone_target_temperature(zone, target_temperature)
         if math.isclose(zone.target_temperature, target_temperature, abs_tol=0.01):
             return
 
         zone.target_temperature = target_temperature
         self._persist_zone_target_temperature(zone_name, target_temperature)
+        await self.async_refresh()
+
+    async def async_set_all_zone_target_temperatures(self, target_temperature: float) -> None:
+        """Fan one master target change out to every configured zone."""
+        changed_zone_temperatures: dict[str, float] = {}
+        for zone in self.config.zones:
+            clamped_target_temperature = self._clamp_zone_target_temperature(
+                zone,
+                target_temperature,
+            )
+            if math.isclose(
+                zone.target_temperature,
+                clamped_target_temperature,
+                abs_tol=0.01,
+            ):
+                continue
+            zone.target_temperature = clamped_target_temperature
+            changed_zone_temperatures[zone.name] = clamped_target_temperature
+
+        if not changed_zone_temperatures:
+            return
+
+        self._persist_zone_target_temperatures(changed_zone_temperatures)
         await self.async_refresh()
 
     async def async_set_global_force_off(self, enabled: bool) -> None:
@@ -220,23 +243,6 @@ class MultiZoneHeatingCoordinator(DataUpdateCoordinator[RuntimeSnapshot]):
             return
 
         self._global_force_off = enabled
-        await self.async_refresh()
-
-    async def async_set_global_override(self, target_temperature: float) -> None:
-        """Set the system-wide override temperature."""
-        if self._global_override is None:
-            self._global_override = GlobalOverride(target_temperature=target_temperature)
-        else:
-            self._global_override.target_temperature = target_temperature
-            self._global_override.active = True
-        await self.async_refresh()
-
-    async def async_clear_global_override(self) -> None:
-        """Remove the system-wide override temperature."""
-        if self._global_override is None:
-            return
-
-        self._global_override.active = False
         await self.async_refresh()
 
     def get_zone_config(self, zone_name: str) -> ZoneConfig | None:
@@ -260,7 +266,6 @@ class MultiZoneHeatingCoordinator(DataUpdateCoordinator[RuntimeSnapshot]):
         """Build a snapshot, evaluate demand, and dispatch required commands."""
         now = self._utcnow()
         snapshot = self._build_runtime_snapshot()
-        snapshot.global_override = self._global_override
         snapshot.global_force_off = self._global_force_off
         flow_value = snapshot.flow_value
 
@@ -298,7 +303,6 @@ class MultiZoneHeatingCoordinator(DataUpdateCoordinator[RuntimeSnapshot]):
                 previous_demand=self._last_zone_demands.get(zone.name, False),
                 previous_group_demands=self._last_group_demands.get(zone.name),
                 hysteresis=self.config.default_hysteresis,
-                global_override=self._global_override,
                 global_frost_protection_min_temp=self.config.frost_protection_min_temp,
             )
             zone_evaluations.append(evaluation)
@@ -418,20 +422,15 @@ class MultiZoneHeatingCoordinator(DataUpdateCoordinator[RuntimeSnapshot]):
         if self.config_entry is None:
             return
 
+        current_zones = self._config_entry_zone_payload()
         zones = []
-        for zone_data in self.config_entry.data.get("zones", []):
+        for zone_data in current_zones:
             updated_zone_data = dict(zone_data)
             if updated_zone_data.get("name") == zone_name:
                 updated_zone_data["enabled"] = enabled
             zones.append(updated_zone_data)
 
-        self.hass.config_entries.async_update_entry(
-            self.config_entry,
-            data={
-                **self.config_entry.data,
-                "zones": zones,
-            },
-        )
+        self._persist_config_entry_zones(zones)
 
     def _persist_zone_target_temperature(
         self,
@@ -442,12 +441,49 @@ class MultiZoneHeatingCoordinator(DataUpdateCoordinator[RuntimeSnapshot]):
         if self.config_entry is None:
             return
 
+        current_zones = self._config_entry_zone_payload()
         zones = []
-        for zone_data in self.config_entry.data.get("zones", []):
+        for zone_data in current_zones:
             updated_zone_data = dict(zone_data)
             if updated_zone_data.get("name") == zone_name:
                 updated_zone_data["target_temperature"] = target_temperature
             zones.append(updated_zone_data)
+
+        self._persist_config_entry_zones(zones)
+
+    def _persist_zone_target_temperatures(
+        self,
+        target_temperatures: Mapping[str, float],
+    ) -> None:
+        """Persist a set of zone target updates into the config entry."""
+        if self.config_entry is None:
+            return
+
+        current_zones = self._config_entry_zone_payload()
+        zones = []
+        for zone_data in current_zones:
+            updated_zone_data = dict(zone_data)
+            zone_name = updated_zone_data.get("name")
+            if zone_name in target_temperatures:
+                updated_zone_data["target_temperature"] = target_temperatures[zone_name]
+            zones.append(updated_zone_data)
+
+        self._persist_config_entry_zones(zones)
+
+    def _persist_config_entry_zones(self, zones: list[dict[str, Any]]) -> None:
+        """Persist zones to whichever config-entry payload currently owns them."""
+        if self.config_entry is None:
+            return
+
+        if "zones" in self.config_entry.options:
+            self.hass.config_entries.async_update_entry(
+                self.config_entry,
+                options={
+                    **self.config_entry.options,
+                    "zones": zones,
+                },
+            )
+            return
 
         self.hass.config_entries.async_update_entry(
             self.config_entry,
@@ -456,6 +492,32 @@ class MultiZoneHeatingCoordinator(DataUpdateCoordinator[RuntimeSnapshot]):
                 "zones": zones,
             },
         )
+
+    def _config_entry_zone_payload(self) -> list[dict[str, Any]]:
+        """Return the current zone payload, preferring options when they own it."""
+        if self.config_entry is None:
+            return []
+
+        zone_payload = self.config_entry.options.get("zones")
+        if isinstance(zone_payload, list):
+            return zone_payload
+        zone_payload = self.config_entry.data.get("zones")
+        if isinstance(zone_payload, list):
+            return zone_payload
+        return []
+
+    def _clamp_zone_target_temperature(
+        self,
+        zone: ZoneConfig,
+        target_temperature: float,
+    ) -> float:
+        """Clamp a zone target to the effective frost floor."""
+        minimums = [5.0]
+        if self.config.frost_protection_min_temp is not None:
+            minimums.append(self.config.frost_protection_min_temp)
+        if zone.frost_protection_min_temp is not None:
+            minimums.append(zone.frost_protection_min_temp)
+        return max(target_temperature, max(minimums))
 
     async def _async_dispatch_zone_commands(
         self,

--- a/custom_components/multi_zone_heating/coordinator.py
+++ b/custom_components/multi_zone_heating/coordinator.py
@@ -147,9 +147,13 @@ class MultiZoneHeatingCoordinator(DataUpdateCoordinator[RuntimeSnapshot]):
         self._last_zone_demands: dict[str, bool] = {}
         self._last_group_demands: dict[str, dict[str, bool]] = {}
         self._last_commanded_switch_states: dict[str, bool] = {}
+        self._last_observed_switch_states: dict[str, bool] = {}
         self._last_commanded_number_values: dict[str, float] = {}
+        self._last_observed_number_values: dict[str, float] = {}
         self._last_commanded_climate_targets: dict[str, float] = {}
+        self._last_observed_climate_targets: dict[str, float] = {}
         self._last_commanded_climate_hvac_modes: dict[str, HVACMode] = {}
+        self._last_observed_climate_hvac_modes: dict[str, HVACMode] = {}
         self._relay_runtime_state = RelayRuntimeState(is_on=False)
         self._global_override: GlobalOverride | None = None
         self._global_force_off = False
@@ -359,7 +363,9 @@ class MultiZoneHeatingCoordinator(DataUpdateCoordinator[RuntimeSnapshot]):
         actuator_available_entity_ids: set[str] = set()
 
         for zone in self.config.zones:
-            snapshot.target_temperatures[zone.name] = self._read_target_temperature(zone)
+            snapshot.target_temperatures[zone.name] = self._read_owned_zone_target_temperature(
+                zone
+            )
 
             for sensor_entity_id in zone.sensor_entity_ids:
                 sensor_value = self._read_numeric_state(sensor_entity_id)
@@ -505,6 +511,15 @@ class MultiZoneHeatingCoordinator(DataUpdateCoordinator[RuntimeSnapshot]):
 
             current_hvac_mode = self._read_climate_hvac_mode(entity_id)
             if current_hvac_mode is not None:
+                previous_hvac_mode = self._remember_observed_climate_hvac_mode(
+                    entity_id,
+                    current_hvac_mode,
+                )
+                self._clear_climate_hvac_mode_if_drifted(
+                    entity_id,
+                    current_hvac_mode,
+                    previous_hvac_mode,
+                )
                 self._clear_climate_hvac_mode_if_synced(entity_id, current_hvac_mode)
 
             hvac_modes = self._read_supported_hvac_modes(entity_id)
@@ -517,6 +532,16 @@ class MultiZoneHeatingCoordinator(DataUpdateCoordinator[RuntimeSnapshot]):
                     continue
 
                 current_target = _as_float(state.attributes.get("temperature"))
+                if current_target is not None:
+                    previous_target = self._remember_observed_climate_target(
+                        entity_id,
+                        current_target,
+                    )
+                    self._clear_climate_target_if_drifted(
+                        entity_id,
+                        current_target,
+                        previous_target,
+                    )
                 if current_target is not None and math.isclose(
                     current_target, target_temperature, abs_tol=0.01
                 ):
@@ -551,6 +576,16 @@ class MultiZoneHeatingCoordinator(DataUpdateCoordinator[RuntimeSnapshot]):
                 continue
 
             current_target = _as_float(state.attributes.get("temperature"))
+            if current_target is not None:
+                previous_target = self._remember_observed_climate_target(
+                    entity_id,
+                    current_target,
+                )
+                self._clear_climate_target_if_drifted(
+                    entity_id,
+                    current_target,
+                    previous_target,
+                )
             if current_target is not None and math.isclose(
                 current_target, fallback_temperature, abs_tol=0.01
             ):
@@ -589,6 +624,9 @@ class MultiZoneHeatingCoordinator(DataUpdateCoordinator[RuntimeSnapshot]):
                 continue
 
             current_value = self._read_numeric_state(entity_id)
+            if current_value is not None:
+                previous_value = self._remember_observed_number_value(entity_id, current_value)
+                self._clear_number_value_if_drifted(entity_id, current_value, previous_value)
             if current_value is not None and math.isclose(current_value, desired_value, abs_tol=0.01):
                 self._last_commanded_number_values.pop(entity_id, None)
                 continue
@@ -639,6 +677,9 @@ class MultiZoneHeatingCoordinator(DataUpdateCoordinator[RuntimeSnapshot]):
             return
 
         current_state = self._read_toggle_state(entity_id)
+        if current_state is not None:
+            previous_state = self._remember_observed_switch_state(entity_id, current_state)
+            self._clear_toggle_state_if_drifted(entity_id, current_state, previous_state)
         if current_state is desired_on:
             self._last_commanded_switch_states.pop(entity_id, None)
             return
@@ -662,6 +703,16 @@ class MultiZoneHeatingCoordinator(DataUpdateCoordinator[RuntimeSnapshot]):
     ) -> None:
         """Set a climate entity HVAC mode only when required."""
         current_hvac_mode = self._read_climate_hvac_mode(entity_id)
+        if current_hvac_mode is not None:
+            previous_hvac_mode = self._remember_observed_climate_hvac_mode(
+                entity_id,
+                current_hvac_mode,
+            )
+            self._clear_climate_hvac_mode_if_drifted(
+                entity_id,
+                current_hvac_mode,
+                previous_hvac_mode,
+            )
         if current_hvac_mode == desired_hvac_mode:
             self._last_commanded_climate_hvac_modes.pop(entity_id, None)
             return
@@ -690,8 +741,108 @@ class MultiZoneHeatingCoordinator(DataUpdateCoordinator[RuntimeSnapshot]):
         if self._last_commanded_climate_hvac_modes.get(entity_id) == current_hvac_mode:
             self._last_commanded_climate_hvac_modes.pop(entity_id, None)
 
-    def _read_target_temperature(self, zone: ZoneConfig) -> float | None:
-        """Read the configured integration-owned zone target."""
+    def _remember_observed_switch_state(
+        self,
+        entity_id: str,
+        current_state: bool,
+    ) -> bool | None:
+        """Store the latest observed toggle state and return the previous one."""
+        previous_state = self._last_observed_switch_states.get(entity_id)
+        self._last_observed_switch_states[entity_id] = current_state
+        return previous_state
+
+    def _clear_toggle_state_if_drifted(
+        self,
+        entity_id: str,
+        current_state: bool,
+        previous_state: bool | None,
+    ) -> None:
+        """Clear a pending toggle command once a different observed state appears."""
+        last_commanded = self._last_commanded_switch_states.get(entity_id)
+        if last_commanded is None or previous_state is None:
+            return
+        if current_state != previous_state and current_state != last_commanded:
+            self._last_commanded_switch_states.pop(entity_id, None)
+
+    def _remember_observed_number_value(
+        self,
+        entity_id: str,
+        current_value: float,
+    ) -> float | None:
+        """Store the latest observed number value and return the previous one."""
+        previous_value = self._last_observed_number_values.get(entity_id)
+        self._last_observed_number_values[entity_id] = current_value
+        return previous_value
+
+    def _clear_number_value_if_drifted(
+        self,
+        entity_id: str,
+        current_value: float,
+        previous_value: float | None,
+    ) -> None:
+        """Clear a pending number command after the entity drifts externally."""
+        last_commanded = self._last_commanded_number_values.get(entity_id)
+        if last_commanded is None or previous_value is None:
+            return
+        if not math.isclose(current_value, previous_value, abs_tol=0.01) and not math.isclose(
+            current_value, last_commanded, abs_tol=0.01
+        ):
+            self._last_commanded_number_values.pop(entity_id, None)
+
+    def _remember_observed_climate_target(
+        self,
+        entity_id: str,
+        current_target: float,
+    ) -> float | None:
+        """Store the latest observed climate target and return the previous one."""
+        previous_target = self._last_observed_climate_targets.get(entity_id)
+        self._last_observed_climate_targets[entity_id] = current_target
+        return previous_target
+
+    def _clear_climate_target_if_drifted(
+        self,
+        entity_id: str,
+        current_target: float,
+        previous_target: float | None,
+    ) -> None:
+        """Clear a pending climate target command after external target drift."""
+        last_target = self._last_commanded_climate_targets.get(entity_id)
+        if last_target is None or previous_target is None:
+            return
+        if not math.isclose(current_target, previous_target, abs_tol=0.01) and not math.isclose(
+            current_target, last_target, abs_tol=0.01
+        ):
+            self._last_commanded_climate_targets.pop(entity_id, None)
+
+    def _remember_observed_climate_hvac_mode(
+        self,
+        entity_id: str,
+        current_hvac_mode: HVACMode,
+    ) -> HVACMode | None:
+        """Store the latest observed HVAC mode and return the previous one."""
+        previous_hvac_mode = self._last_observed_climate_hvac_modes.get(entity_id)
+        self._last_observed_climate_hvac_modes[entity_id] = current_hvac_mode
+        return previous_hvac_mode
+
+    def _clear_climate_hvac_mode_if_drifted(
+        self,
+        entity_id: str,
+        current_hvac_mode: HVACMode,
+        previous_hvac_mode: HVACMode | None,
+    ) -> None:
+        """Clear a pending HVAC-mode command once a different observed mode appears."""
+        last_hvac_mode = self._last_commanded_climate_hvac_modes.get(entity_id)
+        if last_hvac_mode is None or previous_hvac_mode is None:
+            return
+        if current_hvac_mode != previous_hvac_mode and current_hvac_mode != last_hvac_mode:
+            self._last_commanded_climate_hvac_modes.pop(entity_id, None)
+
+    def _read_owned_zone_target_temperature(self, zone: ZoneConfig) -> float | None:
+        """Read the integration-owned zone target.
+
+        Slave actuators are never treated as target sources. Their runtime state is
+        observed only for availability and command deduplication.
+        """
         return zone.target_temperature
 
     def _read_numeric_state(self, entity_id: str | None) -> float | None:

--- a/custom_components/multi_zone_heating/coordinator.py
+++ b/custom_components/multi_zone_heating/coordinator.py
@@ -563,6 +563,8 @@ class MultiZoneHeatingCoordinator(DataUpdateCoordinator[RuntimeSnapshot]):
         force_off: bool,
     ) -> None:
         """Synchronize climate actuators with the effective target temperature."""
+        zone_master_active = zone.enabled and not force_off
+
         for entity_id in zone.climate_entity_ids:
             if not self._entity_is_available(entity_id):
                 continue
@@ -576,8 +578,8 @@ class MultiZoneHeatingCoordinator(DataUpdateCoordinator[RuntimeSnapshot]):
                 self._clear_climate_hvac_mode_if_synced(entity_id, current_hvac_mode)
 
             hvac_modes = self._read_supported_hvac_modes(entity_id)
-            if evaluation.demand and not force_off:
-                if HVACMode.HEAT in hvac_modes and current_hvac_mode == HVACMode.OFF:
+            if zone_master_active:
+                if HVACMode.HEAT in hvac_modes and current_hvac_mode != HVACMode.HEAT:
                     await self._async_dispatch_climate_hvac_mode(entity_id, HVACMode.HEAT)
 
                 target_temperature = evaluation.effective_target_temperature

--- a/custom_components/multi_zone_heating/coordinator.py
+++ b/custom_components/multi_zone_heating/coordinator.py
@@ -19,7 +19,7 @@ from homeassistant.components.climate import (
 )
 from homeassistant.components.number import ATTR_VALUE, SERVICE_SET_VALUE
 from homeassistant.const import ATTR_ENTITY_ID, SERVICE_TURN_OFF, SERVICE_TURN_ON, STATE_ON, STATE_UNAVAILABLE, STATE_UNKNOWN
-from homeassistant.core import CALLBACK_TYPE, Event, HomeAssistant, callback
+from homeassistant.core import CALLBACK_TYPE, HomeAssistant, callback
 from homeassistant.helpers.event import async_track_point_in_utc_time, async_track_state_change_event
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 from homeassistant.util import dt as dt_util
@@ -41,7 +41,6 @@ from .models import (
     RelayDecision,
     RelayRuntimeState,
     RuntimeSnapshot,
-    TargetSourceType,
     ZoneConfig,
     ZoneEvaluation,
 )
@@ -71,8 +70,7 @@ def _zone_from_dict(data: Mapping[str, Any]) -> ZoneConfig:
     return ZoneConfig(
         name=str(data["name"]),
         control_type=ControlType(data["control_type"]),
-        target_source=TargetSourceType(data["target_source"]),
-        target_entity_id=str(data["target_entity_id"]),
+        target_temperature=_as_float(data.get("target_temperature")) or 20.0,
         sensor_entity_ids=list(data.get("sensor_entity_ids", [])),
         climate_entity_ids=list(data.get("climate_entity_ids", [])),
         climate_off_fallback_temperature=_as_float(
@@ -181,9 +179,8 @@ class MultiZoneHeatingCoordinator(DataUpdateCoordinator[RuntimeSnapshot]):
         self._cancel_recheck()
 
     @callback
-    def _async_handle_relevant_state_change(self, event: Event[Any]) -> None:
+    def _async_handle_relevant_state_change(self, _event: Any) -> None:
         """Reevaluate the system when a relevant entity changes."""
-        self._clear_override_on_target_change(event)
         self.hass.async_create_task(self.async_request_refresh())
 
     async def async_set_zone_enabled(self, zone_name: str, enabled: bool) -> None:
@@ -336,8 +333,6 @@ class MultiZoneHeatingCoordinator(DataUpdateCoordinator[RuntimeSnapshot]):
 
         for zone in self.config.zones:
             snapshot.target_temperatures[zone.name] = self._read_target_temperature(zone)
-            if snapshot.target_temperatures[zone.name] is None:
-                unavailable_entity_ids.add(zone.target_entity_id)
 
             for sensor_entity_id in zone.sensor_entity_ids:
                 sensor_value = self._read_numeric_state(sensor_entity_id)
@@ -385,31 +380,6 @@ class MultiZoneHeatingCoordinator(DataUpdateCoordinator[RuntimeSnapshot]):
         snapshot.unavailable_entity_ids = sorted(unavailable_entity_ids)
         return snapshot
 
-    def _clear_override_on_target_change(self, event: Event[Any]) -> None:
-        """Clear the global override when a zone target changes externally."""
-        if self._global_override is None or not self._global_override.active:
-            return
-
-        entity_id = event.data.get("entity_id")
-        if entity_id is None:
-            return
-
-        zone_target_entity_ids = {zone.target_entity_id for zone in self.config.zones}
-        if entity_id not in zone_target_entity_ids:
-            return
-
-        old_state = event.data.get("old_state")
-        new_state = event.data.get("new_state")
-        if old_state is None or new_state is None:
-            return
-
-        old_temperature = self._extract_target_temperature(entity_id, old_state)
-        new_temperature = self._extract_target_temperature(entity_id, new_state)
-        if old_temperature == new_temperature:
-            return
-
-        self._global_override.active = False
-
     def _persist_zone_enabled(self, zone_name: str, enabled: bool) -> None:
         """Persist the zone-enabled flag into the config entry data."""
         if self.config_entry is None:
@@ -429,12 +399,6 @@ class MultiZoneHeatingCoordinator(DataUpdateCoordinator[RuntimeSnapshot]):
                 "zones": zones,
             },
         )
-
-    def _extract_target_temperature(self, entity_id: str, state: Any) -> float | None:
-        """Read the comparable target value from a target entity state."""
-        if entity_id.split(".", 1)[0] == CLIMATE_DOMAIN:
-            return _as_float(state.attributes.get("temperature"))
-        return _as_float(state.state)
 
     async def _async_dispatch_zone_commands(
         self,
@@ -676,15 +640,8 @@ class MultiZoneHeatingCoordinator(DataUpdateCoordinator[RuntimeSnapshot]):
             self._last_commanded_climate_hvac_modes.pop(entity_id, None)
 
     def _read_target_temperature(self, zone: ZoneConfig) -> float | None:
-        """Read the configured zone target from its source entity."""
-        state = self.hass.states.get(zone.target_entity_id)
-        if state is None or state.state in {STATE_UNKNOWN, STATE_UNAVAILABLE}:
-            return None
-
-        if zone.target_source is TargetSourceType.CLIMATE:
-            return _as_float(state.attributes.get("temperature"))
-
-        return _as_float(state.state)
+        """Read the configured integration-owned zone target."""
+        return zone.target_temperature
 
     def _read_numeric_state(self, entity_id: str | None) -> float | None:
         """Read a numeric state from Home Assistant."""
@@ -783,7 +740,6 @@ def _iter_relevant_entity_ids(config: IntegrationConfig) -> Iterable[str]:
         yield config.flow_sensor_entity_id
 
     for zone in config.zones:
-        yield zone.target_entity_id
         yield from zone.sensor_entity_ids
         yield from zone.climate_entity_ids
         for group in zone.local_groups:

--- a/custom_components/multi_zone_heating/coordinator.py
+++ b/custom_components/multi_zone_heating/coordinator.py
@@ -511,15 +511,6 @@ class MultiZoneHeatingCoordinator(DataUpdateCoordinator[RuntimeSnapshot]):
 
             current_hvac_mode = self._read_climate_hvac_mode(entity_id)
             if current_hvac_mode is not None:
-                previous_hvac_mode = self._remember_observed_climate_hvac_mode(
-                    entity_id,
-                    current_hvac_mode,
-                )
-                self._clear_climate_hvac_mode_if_drifted(
-                    entity_id,
-                    current_hvac_mode,
-                    previous_hvac_mode,
-                )
                 self._clear_climate_hvac_mode_if_synced(entity_id, current_hvac_mode)
 
             hvac_modes = self._read_supported_hvac_modes(entity_id)

--- a/custom_components/multi_zone_heating/coordinator.py
+++ b/custom_components/multi_zone_heating/coordinator.py
@@ -193,6 +193,23 @@ class MultiZoneHeatingCoordinator(DataUpdateCoordinator[RuntimeSnapshot]):
         self._persist_zone_enabled(zone_name, enabled)
         await self.async_refresh()
 
+    async def async_set_zone_target_temperature(
+        self,
+        zone_name: str,
+        target_temperature: float,
+    ) -> None:
+        """Persist and apply the owned target temperature for one zone."""
+        zone = self.get_zone_config(zone_name)
+        if zone is None:
+            return
+
+        if math.isclose(zone.target_temperature, target_temperature, abs_tol=0.01):
+            return
+
+        zone.target_temperature = target_temperature
+        self._persist_zone_target_temperature(zone_name, target_temperature)
+        await self.async_refresh()
+
     async def async_set_global_force_off(self, enabled: bool) -> None:
         """Enable or disable global force-off."""
         if self._global_force_off == enabled:
@@ -223,6 +240,16 @@ class MultiZoneHeatingCoordinator(DataUpdateCoordinator[RuntimeSnapshot]):
         for zone in self.config.zones:
             if zone.name == zone_name:
                 return zone
+        return None
+
+    def get_zone_evaluation(self, zone_name: str) -> ZoneEvaluation | None:
+        """Return the latest evaluation for one configured zone."""
+        if self.data is None:
+            return None
+
+        for evaluation in self.data.zone_evaluations:
+            if evaluation.name == zone_name:
+                return evaluation
         return None
 
     async def _async_update_data(self) -> RuntimeSnapshot:
@@ -390,6 +417,30 @@ class MultiZoneHeatingCoordinator(DataUpdateCoordinator[RuntimeSnapshot]):
             updated_zone_data = dict(zone_data)
             if updated_zone_data.get("name") == zone_name:
                 updated_zone_data["enabled"] = enabled
+            zones.append(updated_zone_data)
+
+        self.hass.config_entries.async_update_entry(
+            self.config_entry,
+            data={
+                **self.config_entry.data,
+                "zones": zones,
+            },
+        )
+
+    def _persist_zone_target_temperature(
+        self,
+        zone_name: str,
+        target_temperature: float,
+    ) -> None:
+        """Persist the owned zone target temperature into the config entry data."""
+        if self.config_entry is None:
+            return
+
+        zones = []
+        for zone_data in self.config_entry.data.get("zones", []):
+            updated_zone_data = dict(zone_data)
+            if updated_zone_data.get("name") == zone_name:
+                updated_zone_data["target_temperature"] = target_temperature
             zones.append(updated_zone_data)
 
         self.hass.config_entries.async_update_entry(

--- a/custom_components/multi_zone_heating/diagnostics.py
+++ b/custom_components/multi_zone_heating/diagnostics.py
@@ -102,21 +102,36 @@ def _zone_climate_diagnostics(coordinator: Any) -> list[dict[str, Any]] | None:
         evaluation = evaluations_by_name.get(zone.name)
         if evaluation is None:
             continue
-        diagnostics.append(_zone_diagnostics(zone, evaluation))
+        diagnostics.append(
+            _zone_diagnostics(
+                zone,
+                evaluation,
+                global_force_off=coordinator.data.global_force_off,
+            )
+        )
     return diagnostics
 
 
-def _zone_diagnostics(zone: ZoneConfig, evaluation: ZoneEvaluation) -> dict[str, Any]:
+def _zone_diagnostics(
+    zone: ZoneConfig,
+    evaluation: ZoneEvaluation,
+    *,
+    global_force_off: bool,
+) -> dict[str, Any]:
     """Assemble one zone climate diagnostics record."""
     return {
         "name": zone.name,
         "hvac_mode": "heat" if zone.enabled else "off",
         "hvac_action": (
-            "off" if not zone.enabled else "heating" if evaluation.demand else "idle"
+            "off"
+            if not zone.enabled or global_force_off
+            else "heating" if evaluation.demand else "idle"
         ),
         "control_type": zone.control_type.value,
         "aggregation_mode": zone.aggregation_mode.value,
         "enabled": zone.enabled,
+        "demand": evaluation.demand,
+        "global_force_off": global_force_off,
         "target_temperature": evaluation.target_temperature,
         "effective_target_temperature": evaluation.effective_target_temperature,
         "current_temperature": evaluation.current_temperature,

--- a/custom_components/multi_zone_heating/diagnostics.py
+++ b/custom_components/multi_zone_heating/diagnostics.py
@@ -10,6 +10,7 @@ from typing import Any
 from homeassistant.core import HomeAssistant
 
 from . import MultiZoneHeatingConfigEntry
+from .models import ZoneConfig, ZoneEvaluation
 
 
 async def async_get_config_entry_diagnostics(
@@ -35,8 +36,93 @@ async def async_get_config_entry_diagnostics(
             "global_force_off": coordinator.data.global_force_off
             if coordinator is not None and coordinator.data is not None
             else None,
+            "system_climate": _system_climate_diagnostics(coordinator),
+            "zone_climates": _zone_climate_diagnostics(coordinator),
             "snapshot": _serialize_value(coordinator.data) if coordinator is not None else None,
         },
+    }
+
+
+def _system_climate_diagnostics(coordinator: Any) -> dict[str, Any] | None:
+    """Return a diagnostics-friendly view of the system climate surface."""
+    if coordinator is None or coordinator.data is None:
+        return None
+
+    visible_temperatures: list[float] = []
+    for evaluation in coordinator.data.zone_evaluations:
+        if evaluation.current_temperature is not None:
+            visible_temperatures.append(evaluation.current_temperature)
+        for group in evaluation.local_groups:
+            if group.current_temperature is not None:
+                visible_temperatures.append(group.current_temperature)
+
+    targets = {
+        evaluation.target_temperature
+        for evaluation in coordinator.data.zone_evaluations
+        if evaluation.target_temperature is not None
+    }
+    target_temperature = next(iter(targets)) if len(targets) == 1 else None
+
+    return {
+        "hvac_mode": "off" if coordinator.data.global_force_off else "heat",
+        "hvac_action": (
+            "off"
+            if coordinator.data.global_force_off
+            else "heating" if coordinator.data.system_demand else "idle"
+        ),
+        "target_temperature": target_temperature,
+        "current_temperature": (
+            sum(visible_temperatures) / len(visible_temperatures)
+            if visible_temperatures
+            else None
+        ),
+        "zones_calling_for_heat": [
+            evaluation.name
+            for evaluation in coordinator.data.zone_evaluations
+            if evaluation.demand
+        ],
+        "zone_target_temperatures": {
+            evaluation.name: evaluation.target_temperature
+            for evaluation in coordinator.data.zone_evaluations
+        },
+        "global_force_off": coordinator.data.global_force_off,
+    }
+
+
+def _zone_climate_diagnostics(coordinator: Any) -> list[dict[str, Any]] | None:
+    """Return zone climate details that reflect the owned target model."""
+    if coordinator is None or coordinator.data is None:
+        return None
+
+    diagnostics: list[dict[str, Any]] = []
+    evaluations_by_name = {
+        evaluation.name: evaluation for evaluation in coordinator.data.zone_evaluations
+    }
+    for zone in coordinator.config.zones:
+        evaluation = evaluations_by_name.get(zone.name)
+        if evaluation is None:
+            continue
+        diagnostics.append(_zone_diagnostics(zone, evaluation))
+    return diagnostics
+
+
+def _zone_diagnostics(zone: ZoneConfig, evaluation: ZoneEvaluation) -> dict[str, Any]:
+    """Assemble one zone climate diagnostics record."""
+    return {
+        "name": zone.name,
+        "hvac_mode": "heat" if zone.enabled else "off",
+        "hvac_action": (
+            "off" if not zone.enabled else "heating" if evaluation.demand else "idle"
+        ),
+        "control_type": zone.control_type.value,
+        "aggregation_mode": zone.aggregation_mode.value,
+        "enabled": zone.enabled,
+        "target_temperature": evaluation.target_temperature,
+        "effective_target_temperature": evaluation.effective_target_temperature,
+        "current_temperature": evaluation.current_temperature,
+        "available_sensor_entity_ids": evaluation.available_sensor_entity_ids,
+        "available_actuator_entity_ids": evaluation.available_actuator_entity_ids,
+        "local_groups": _serialize_value(evaluation.local_groups),
     }
 
 

--- a/custom_components/multi_zone_heating/models.py
+++ b/custom_components/multi_zone_heating/models.py
@@ -94,14 +94,6 @@ class RuntimeData:
 
 
 @dataclass(slots=True)
-class GlobalOverride:
-    """Represents the optional system-wide target override."""
-
-    target_temperature: float
-    active: bool = True
-
-
-@dataclass(slots=True)
 class LocalControlGroupEvaluation:
     """Pure evaluation result for a local control group."""
 
@@ -172,7 +164,6 @@ class RuntimeSnapshot:
 
     sensor_values: dict[str, float | None] = field(default_factory=dict)
     target_temperatures: dict[str, float | None] = field(default_factory=dict)
-    global_override: GlobalOverride | None = None
     global_force_off: bool = False
     flow_value: float | None = None
     flow_detected: bool = False

--- a/custom_components/multi_zone_heating/models.py
+++ b/custom_components/multi_zone_heating/models.py
@@ -27,13 +27,6 @@ class ControlType(StrEnum):
     SWITCH = "switch"
 
 
-class TargetSourceType(StrEnum):
-    """Supported target temperature source types."""
-
-    CLIMATE = "climate"
-    INPUT_NUMBER = "input_number"
-
-
 class NumberSemanticType(StrEnum):
     """Supported meanings for number-based actuators."""
 
@@ -62,8 +55,7 @@ class ZoneConfig:
 
     name: str
     control_type: ControlType
-    target_source: TargetSourceType
-    target_entity_id: str
+    target_temperature: float
     sensor_entity_ids: list[str] = field(default_factory=list)
     climate_entity_ids: list[str] = field(default_factory=list)
     climate_off_fallback_temperature: float | None = None

--- a/custom_components/multi_zone_heating/services.yaml
+++ b/custom_components/multi_zone_heating/services.yaml
@@ -1,3 +1,0 @@
-clear_override:
-  name: Clear Override
-  description: Clear the active global override target temperature for all loaded multi-zone heating entries.

--- a/custom_components/multi_zone_heating/strings.json
+++ b/custom_components/multi_zone_heating/strings.json
@@ -12,7 +12,6 @@
       "number_values_required": "Number control groups need active and inactive values.",
       "primary_sensor_not_in_sensors": "The primary sensor must be one of the selected sensors.",
       "primary_sensor_required": "Select a primary sensor when using primary aggregation.",
-      "target_entity_domain_mismatch": "The target entity must match the selected target source type.",
       "zone_name_required": "Each zone needs a name.",
       "zone_requires_climate_entities": "Climate zones need at least one climate entity.",
       "zone_requires_sensors": "Climate zones need at least one temperature sensor."
@@ -41,9 +40,7 @@
           "control_type": "Control type",
           "enabled": "Enabled",
           "frost_protection_min_temp": "Zone frost minimum",
-          "name": "Zone name",
-          "target_entity_id": "Target entity",
-          "target_source": "Target source"
+          "name": "Zone name"
         }
       },
       "climate_zone": {
@@ -96,7 +93,6 @@
       "number_values_required": "Number control groups need active and inactive values.",
       "primary_sensor_not_in_sensors": "The primary sensor must be one of the selected sensors.",
       "primary_sensor_required": "Select a primary sensor when using primary aggregation.",
-      "target_entity_domain_mismatch": "The target entity must match the selected target source type.",
       "zone_name_required": "Each zone needs a name.",
       "zone_requires_climate_entities": "Climate zones need at least one climate entity.",
       "zone_requires_local_groups": "Switch and number zones need at least one local control group.",
@@ -146,9 +142,7 @@
           "control_type": "Control type",
           "enabled": "Enabled",
           "frost_protection_min_temp": "Zone frost minimum",
-          "name": "Zone name",
-          "target_entity_id": "Target entity",
-          "target_source": "Target source"
+          "name": "Zone name"
         }
       },
       "climate_zone": {

--- a/custom_components/multi_zone_heating/target_temperature.py
+++ b/custom_components/multi_zone_heating/target_temperature.py
@@ -1,0 +1,18 @@
+"""Helpers for integration-owned zone target temperatures."""
+
+from __future__ import annotations
+
+from .const import DEFAULT_ZONE_TARGET_TEMPERATURE
+
+
+def initial_zone_target_temperature(
+    global_frost_protection_min_temp: object | None,
+    zone_frost_protection_min_temp: object | None,
+) -> float:
+    """Compute the initial owned zone target with frost floors applied."""
+    target_temperature = DEFAULT_ZONE_TARGET_TEMPERATURE
+    for floor in (global_frost_protection_min_temp, zone_frost_protection_min_temp):
+        if floor is None:
+            continue
+        target_temperature = max(target_temperature, float(floor))
+    return target_temperature

--- a/custom_components/multi_zone_heating/translations/en.json
+++ b/custom_components/multi_zone_heating/translations/en.json
@@ -12,7 +12,6 @@
       "number_values_required": "Number control groups need active and inactive values.",
       "primary_sensor_not_in_sensors": "The primary sensor must be one of the selected sensors.",
       "primary_sensor_required": "Select a primary sensor when using primary aggregation.",
-      "target_entity_domain_mismatch": "The target entity must match the selected target source type.",
       "zone_name_required": "Each zone needs a name.",
       "zone_requires_climate_entities": "Climate zones need at least one climate entity.",
       "zone_requires_sensors": "Climate zones need at least one temperature sensor."
@@ -41,9 +40,7 @@
           "control_type": "Control type",
           "enabled": "Enabled",
           "frost_protection_min_temp": "Zone frost minimum",
-          "name": "Zone name",
-          "target_entity_id": "Target entity",
-          "target_source": "Target source"
+          "name": "Zone name"
         }
       },
       "climate_zone": {
@@ -96,7 +93,6 @@
       "number_values_required": "Number control groups need active and inactive values.",
       "primary_sensor_not_in_sensors": "The primary sensor must be one of the selected sensors.",
       "primary_sensor_required": "Select a primary sensor when using primary aggregation.",
-      "target_entity_domain_mismatch": "The target entity must match the selected target source type.",
       "zone_name_required": "Each zone needs a name.",
       "zone_requires_climate_entities": "Climate zones need at least one climate entity.",
       "zone_requires_local_groups": "Switch and number zones need at least one local control group.",
@@ -146,9 +142,7 @@
           "control_type": "Control type",
           "enabled": "Enabled",
           "frost_protection_min_temp": "Zone frost minimum",
-          "name": "Zone name",
-          "target_entity_id": "Target entity",
-          "target_source": "Target source"
+          "name": "Zone name"
         }
       },
       "climate_zone": {

--- a/docs/implementation-plan.md
+++ b/docs/implementation-plan.md
@@ -32,6 +32,7 @@ Version 1 includes:
 - Global and per-zone frost protection minimums
 - Zone and system demand entities
 - Top-level climate entity with master control semantics
+- Slave climate HVAC mode following the virtual zone master instead of demand edges
 - Diagnostics and warnings
 - Config migration away from `target_source` and `target_entity_id`
 
@@ -156,6 +157,7 @@ Support all three zone and actuator control styles with zone climates as masters
 Deliverables:
 
 - Slave climate zone handling
+- Slave climate target sync while zone-enabled master state owns `heat` or `off`
 - Switch local control group handling
 - Number local control group handling
 - Shared zone target behavior across groups
@@ -181,6 +183,7 @@ Deliverables:
 - Numeric flow threshold support
 - Demand-without-flow warning handling
 - Per-zone enable or disable
+- Zone climate HVAC mode aligned with zone enable or disable state
 - Global force-off behavior
 - Top-level climate semantics aligned with zone-owned targets
 
@@ -225,6 +228,7 @@ Related stories:
 - The zone climate is the only source of truth for that zone target
 - External climate entities, if configured, are slave actuators only
 - The coordinator must not read target temperature from slave entities
+- The zone climate `hvac_mode` is the canonical enabled or disabled state for the zone
 
 ### Zone Climate Temperature Presentation
 
@@ -240,6 +244,13 @@ Related stories:
 - `heat` clears global force-off
 - If it supports target writes, they must update zone-owned targets through integration logic
 - It must not reintroduce external target-source ownership indirectly
+
+### Slave Climate Behavior
+
+- Slave climate targets follow the zone-owned target while the zone is enabled
+- Slave climate HVAC mode follows the virtual zone or global master state, not momentary demand transitions
+- Clearing zone demand must not turn slave climates `off` by itself
+- Zone disable and global force-off may turn slave climates `off` or apply a configured fallback target where `off` is unsupported
 
 ### Frost Protection
 

--- a/docs/implementation-plan.md
+++ b/docs/implementation-plan.md
@@ -8,7 +8,7 @@ The plan is optimized for:
 
 - Early end-to-end validation
 - Low rework between milestones
-- Clear separation between data modeling, control logic, and Home Assistant entity surfaces
+- Clear separation between data modeling, control logic, runtime ownership, and Home Assistant entity surfaces
 
 ## Version 1 Scope
 
@@ -16,9 +16,12 @@ Version 1 includes:
 
 - Config flow and options flow
 - Multiple zones
+- One virtual climate entity per zone
+- Integration-owned persistence of zone target temperatures
 - Zone control types: `climate`, `switch`, `number`
 - Local control groups for `switch` and `number`
 - Multi-sensor aggregation with `average`, `minimum`, and `primary`
+- Zone climate `current_temperature` derived from the configured aggregation algorithm
 - Global hysteresis
 - Main relay control
 - Numeric flow meter thresholding
@@ -28,8 +31,9 @@ Version 1 includes:
 - Global force-off
 - Global and per-zone frost protection minimums
 - Zone and system demand entities
-- Top-level climate entity with global override target
+- Top-level climate entity with master control semantics
 - Diagnostics and warnings
+- Config migration away from `target_source` and `target_entity_id`
 
 ## Architecture Summary
 
@@ -38,102 +42,122 @@ The integration should be built around four layers:
 1. Configuration layer
    Config flow, options flow, config-entry persistence, migration support
 2. Domain model and control logic layer
-   Pure Python models and decision logic for temperatures, demand, overrides, relay state, and fault handling
+   Pure Python models and decision logic for temperatures, demand, frost protection, relay state, and fault handling
 3. Runtime coordinator layer
-   Home Assistant state subscriptions, scheduling, command dispatch, and transition handling
+   Home Assistant state subscriptions, zone-target persistence ownership, scheduling, and slave command dispatch
 4. Entity layer
-   Binary sensors, sensors, switches, and the top-level climate entity
+   Zone climates, system climate, binary sensors, sensors, and switches
 
 ## Delivery Strategy
 
-Build the integration in vertical slices with an emphasis on getting a basic end-to-end system running early.
+Build the integration in vertical slices with an emphasis on getting a stable master / slave model working early.
 
 Recommended order:
 
-1. Scaffold the integration and basic config entry setup
-2. Implement models and pure control logic
-3. Implement runtime coordinator and relay control
-4. Add climate-controlled zones
-5. Add switch and number local control groups
-6. Add flow meter handling and warnings
-7. Add entities, overrides, and top-level climate behavior
-8. Add editing flows, diagnostics polish, and tests
+1. Replace the zone target config model and add migration support
+2. Implement integration-owned zone target persistence
+3. Add zone virtual climate entities
+4. Update runtime coordinator to read zone targets from owned zone climate state only
+5. Update slave actuator dispatch for `climate`, `switch`, and `number`
+6. Add relay, flow, and diagnostics behavior
+7. Add top-level climate behavior aligned with the new model
+8. Finish options flow, diagnostics polish, and tests
 
 ## Milestones
 
-### Milestone 1: Foundation
+### Milestone 1: Schema And Migration
 
 Goal:
-Create a loadable custom integration with config entry plumbing, constants, models, and a testable project structure.
+Replace external target-entity configuration with zone-owned target state and migration support.
 
 Deliverables:
 
-- `custom_components/multi_zone_heating/` scaffold
-- `manifest.json`
-- `__init__.py`
-- `const.py`
-- `models.py`
-- Base config entry setup and unload support
-- Initial test scaffolding
+- Updated config schema without `target_source` or `target_entity_id`
+- Config-entry migration logic
+- Updated config flow and options flow forms
+- Tests for new and migrated config entries
 
 Related stories:
 
 - US-001
 - US-002
+- US-024
 
 ### Milestone 2: Core Decision Engine
 
 Goal:
-Implement pure logic for temperature aggregation, demand state transitions, frost protection, override evaluation, and relay timing.
+Implement pure logic for temperature aggregation, demand state transitions, frost protection, and relay timing using integration-owned zone targets.
 
 Deliverables:
 
-- `control_logic.py`
-- Dataclasses for zones, local groups, actuator targets, and runtime state
+- Updated `models.py`
+- Updated `control_logic.py`
 - Unit tests for aggregation and hysteresis
+- Unit tests that validate zone climate `current_temperature` behavior
 - Unit tests for relay timing rules
 
 Related stories:
 
+- US-005
 - US-006
 - US-007
 - US-008
-- US-013
+- US-009
 - US-014
-- US-020
-- US-021
+- US-015
+- US-022
+- US-023
 
-### Milestone 3: Runtime Coordinator
+### Milestone 3: Zone Climate Ownership
 
 Goal:
-Subscribe to entity changes, evaluate system state, and dispatch commands safely.
+Create the per-zone virtual climate entities and persist zone target temperatures in integration-owned state.
 
 Deliverables:
 
-- `coordinator.py`
+- Zone virtual climate entities in `climate.py`
+- Restore-state behavior for zone targets
+- Zone climate current temperature projection from aggregation logic
+- Coordinator APIs for reading and updating owned zone targets
+
+Related stories:
+
+- US-005
+- US-008
+- US-020
+
+### Milestone 4: Runtime Coordinator
+
+Goal:
+Subscribe to relevant entity changes, evaluate system state, and dispatch commands safely in a strict master / slave model.
+
+Deliverables:
+
+- Updated `coordinator.py`
 - Entity state collection and validation
+- Owned target reads from zone climate state only
 - Scheduled reevaluation support for relay timing
 - Command dispatch helpers
 - Availability tracking for sensors and actuators
 
 Related stories:
 
-- US-008
-- US-012
+- US-009
 - US-013
 - US-014
 - US-015
+- US-016
 
-### Milestone 4: Zone Control Types
+### Milestone 5: Zone Control Types
 
 Goal:
-Support all three zone control styles required for version 1.
+Support all three zone and actuator control styles with zone climates as masters and actuators as slaves.
 
 Deliverables:
 
-- Climate zone handling
-- Switch local control groups
-- Number local control groups
+- Slave climate zone handling
+- Switch local control group handling
+- Number local control group handling
 - Shared zone target behavior across groups
 - Actuator write helpers per control type
 
@@ -141,15 +165,15 @@ Related stories:
 
 - US-003
 - US-004
-- US-005
-- US-009
 - US-010
 - US-011
+- US-012
+- US-013
 
-### Milestone 5: Relay, Flow, and Overrides
+### Milestone 6: Relay, Overrides, And UX
 
 Goal:
-Make whole-system operation reliable and understandable.
+Make whole-system operation reliable and understandable with the new target ownership model.
 
 Deliverables:
 
@@ -158,32 +182,7 @@ Deliverables:
 - Demand-without-flow warning handling
 - Per-zone enable or disable
 - Global force-off behavior
-- Frost protection integration into target resolution
-
-Related stories:
-
-- US-013
-- US-014
-- US-015
-- US-016
-- US-017
-- US-020
-- US-021
-
-### Milestone 6: Entity Surface and UX
-
-Goal:
-Expose the system in Home Assistant with useful entities and a coherent top-level control model.
-
-Deliverables:
-
-- Zone demand binary sensors
-- System demand binary sensor
-- Diagnostic sensors
-- Zone enable switches
-- Global force-off switch
-- Top-level system climate entity
-- `clear_override` service or equivalent action
+- Top-level climate semantics aligned with zone-owned targets
 
 Related stories:
 
@@ -191,24 +190,25 @@ Related stories:
 - US-017
 - US-018
 - US-019
-- US-022
+- US-021
 
-### Milestone 7: Configuration Editing and Quality
+### Milestone 7: Diagnostics And Quality
 
 Goal:
 Make the integration maintainable and ready for real use.
 
 Deliverables:
 
-- Options flow for editing zones and local groups
 - Diagnostics output
 - Integration tests
-- Migration support for evolving config schema
-- User-facing documentation inside the repo
+- Translation updates
+- Documentation updates inside the repo
 
 Related stories:
 
-- US-023
+- US-019
+- US-025
+- US-026
 
 ## Technical Design Decisions
 
@@ -217,25 +217,29 @@ Related stories:
 - Use Home Assistant config flow and options flow only
 - Do not write YAML configuration files
 - Persist user configuration in config entries
+- Persist zone-owned target temperatures in integration-managed state or config
 
-### Flow Meter Handling
+### Zone Climate Ownership
 
-- Flow source is a numeric sensor
-- A configurable threshold determines whether flow is considered present
-- Flow is used to:
-  - delay relay-off until flow falls below threshold
-  - raise warnings when demand exists but flow does not exceed threshold after relay-on
-- Flow is not used to infer zero-demand faults because domestic water heating shares the same meter
+- Each zone has one virtual climate entity owned by this integration
+- The zone climate is the only source of truth for that zone target
+- External climate entities, if configured, are slave actuators only
+- The coordinator must not read target temperature from slave entities
+
+### Zone Climate Temperature Presentation
+
+- `current_temperature` is computed from the configured zone aggregation logic
+- `average` uses the mean of available zone sensors
+- `minimum` uses the lowest available zone sensor
+- `primary` uses the configured primary sensor directly
 
 ### Top-Level Climate Behavior
 
 - Supports `heat` and `off`
 - `off` maps to global force-off
 - `heat` clears global force-off
-- Setting target temperature creates a global override target
-- Override ends when a zone target changes or when explicitly cleared
-- Override persists while HVAC mode is `off`
-- Setting target temperature while `off` stores the override without resuming heating
+- If it supports target writes, they must update zone-owned targets through integration logic
+- It must not reintroduce external target-source ownership indirectly
 
 ### Frost Protection
 
@@ -243,80 +247,3 @@ Related stories:
 - Support global minimum temperature
 - Support per-zone minimum temperature overrides
 - Effective target temperature is never allowed below the applicable frost minimum
-
-## Suggested File Layout
-
-```text
-custom_components/
-  multi_zone_heating/
-    __init__.py
-    manifest.json
-    const.py
-    config_flow.py
-    coordinator.py
-    models.py
-    control_logic.py
-    binary_sensor.py
-    climate.py
-    number.py
-    sensor.py
-    switch.py
-    switch.py
-    climate.py
-    diagnostics.py
-    services.yaml
-    strings.json
-    translations/
-      en.json
-tests/
-  components/
-    multi_zone_heating/
-```
-
-## Risks and Mitigations
-
-### Risk: Complex configuration for local control groups
-
-Mitigation:
-
-- Keep version 1 options flow structured and explicit
-- Favor a small number of required fields
-- Add validation that each local group has both sensors and actuators
-
-### Risk: Climate entity semantics are awkward for "no meaningful target"
-
-Mitigation:
-
-- Expose explicit attributes for override state
-- Retain last override target for compatibility while using `override_active` to express truth
-
-### Risk: Relay timing and flow handling create edge cases
-
-Mitigation:
-
-- Keep timing decisions in pure logic with tests
-- Separate desired relay state from actual relay command timing
-
-### Risk: Availability handling becomes inconsistent between zone types
-
-Mitigation:
-
-- Centralize availability evaluation in shared helpers
-- Test climate zones and local-group zones separately
-
-## Completion Criteria
-
-Version 1 is complete when:
-
-- A user can configure a system fully from the UI
-- All required zone types work
-- Relay behavior is stable
-- Flow warnings and relay-off delay work
-- Override behavior is consistent
-- The top-level climate entity behaves as designed
-- Core logic is covered by tests
-- The integration exposes enough diagnostics for troubleshooting
-
-## Issue Breakdown
-
-Implementation work is split into issue-sized documents under [docs/issues](/Users/jws/Projects/thermostat/docs/issues).

--- a/docs/installation-and-usage.md
+++ b/docs/installation-and-usage.md
@@ -128,10 +128,11 @@ You will configure:
 
 Behavior:
 
-- when the zone demands heat, the integration pushes the effective target temperature to the configured climate entities
-- if the climate entity supports `heat`, it is switched from `off` to `heat` when demand starts
-- when demand stops, the integration turns the climate entity `off` if supported
-- if `off` is not supported, it can instead write the configured fallback temperature
+- while the zone is enabled, the integration pushes the effective target temperature to the configured climate entities
+- slave climate entities follow the virtual zone master for `heat` or `off`
+- when demand stops, the zone becomes idle but slave climates do not switch `off` just because demand cleared
+- when the zone is disabled, or global force-off is active, the integration turns the climate entity `off` if supported
+- if `off` is not supported, it can instead write the configured fallback temperature when the zone is disabled or globally forced off
 
 ### Switch Zone
 
@@ -190,6 +191,11 @@ After setup, the integration creates several runtime entities.
 
 ### Climate
 
+- `climate.<entry>_<zone>`
+  - exposed as the virtual climate entity for one zone
+  - setting its target temperature updates the integration-owned zone target
+  - setting HVAC mode to `off` disables that zone
+  - setting HVAC mode to `heat` re-enables that zone
 - `climate.<entry>_system`
   - exposed as the system climate entity
   - setting its target temperature fans the same setpoint out to every zone climate
@@ -247,7 +253,7 @@ Typical runtime usage is:
 2. Let the integration decide which zones currently demand heat.
 3. Use the system climate entity when you want to push one setpoint to every zone at once.
 4. Use the global force-off switch when you want the whole system disabled without reconfiguring zones.
-5. Disable individual zones with their zone-enabled switches when needed.
+5. Disable individual zones with their zone climate HVAC mode or the mirrored zone-enabled switch when needed.
 
 ## Example Scenarios
 
@@ -256,7 +262,7 @@ Typical runtime usage is:
 - Each room has one or more temperature sensors.
 - Each room has one or more climate TRV entities.
 - Each room target is owned by the integration.
-- The integration writes effective target temperatures to the TRVs and runs the shared boiler relay when any room demands heat.
+- The integration writes effective target temperatures to the TRVs, keeps them aligned to the virtual zone master state, and runs the shared boiler relay when any room demands heat.
 
 ### Example 2: Switch-Driven Zone Valves
 

--- a/docs/installation-and-usage.md
+++ b/docs/installation-and-usage.md
@@ -9,11 +9,11 @@ The integration evaluates heat demand across multiple configured zones and coord
 In version `0.2.0`, it can:
 
 - read one or more temperature sensors per zone or local control group
-- read a target temperature from either a `climate` entity or a `number`/`input_number`
+- persist one owned target temperature per zone
 - drive one or more climate actuators for a climate-based zone
 - drive one or more switch actuators for a switch-based zone
 - drive one or more number actuators for a number-based zone
-- expose system-level control entities for override and force-off behavior
+- expose system-level control entities for master target fan-out and force-off behavior
 - expose diagnostics for demand, relay state, and missing-flow warnings
 
 ## Before You Start
@@ -27,7 +27,6 @@ You should already have:
 Optional but supported:
 
 - a flow sensor entity
-- target temperatures exposed through `climate`, `number`, or `input_number` entities
 
 ## Installation
 
@@ -193,15 +192,15 @@ After setup, the integration creates several runtime entities.
 
 - `climate.<entry>_system`
   - exposed as the system climate entity
-  - setting its target temperature creates a system-wide override
+  - setting its target temperature fans the same setpoint out to every zone climate
   - setting HVAC mode to `off` activates global force-off
   - setting HVAC mode to `heat` clears global force-off
+  - if zone targets differ, its displayed `target_temperature` is empty instead of becoming a separate source of truth
 
 Attributes include:
 
-- `override_active`
-- `override_target_temperature`
 - `zones_calling_for_heat`
+- `zone_target_temperatures`
 - `global_force_off`
 
 ### Binary Sensors
@@ -240,27 +239,13 @@ Diagnostic attributes include:
 - `flow_value`
 - `zones_calling_for_heat`
 
-## Services
-
-The integration registers this service:
-
-- `multi_zone_heating.clear_override`
-  - clears the active global override target temperature for all loaded integration entries
-
-Example service call:
-
-```yaml
-service: multi_zone_heating.clear_override
-data: {}
-```
-
 ## Day-To-Day Usage
 
 Typical runtime usage is:
 
 1. Leave each zone target at its normal room target.
 2. Let the integration decide which zones currently demand heat.
-3. Use the system climate entity only when you want a temporary whole-system override.
+3. Use the system climate entity when you want to push one setpoint to every zone at once.
 4. Use the global force-off switch when you want the whole system disabled without reconfiguring zones.
 5. Disable individual zones with their zone-enabled switches when needed.
 
@@ -335,4 +320,4 @@ Check the relay-state sensor attributes, especially `hold_reason`.
 - switch-group setup
 - number-group setup
 - created entities in the device page
-- example dashboard card showing override and diagnostics
+- example dashboard card showing system fan-out and diagnostics

--- a/docs/installation-and-usage.md
+++ b/docs/installation-and-usage.md
@@ -93,7 +93,7 @@ During the first step, the integration asks for:
 
 ### Zone Types
 
-Each zone has a name, an enabled flag, a control type, a target source, and a target entity.
+Each zone has a name, an enabled flag, a control type, and an integration-owned target temperature.
 
 Supported zone control types in `0.2.0`:
 
@@ -101,12 +101,7 @@ Supported zone control types in `0.2.0`:
 - `switch`
 - `number`
 
-Supported target sources in `0.2.0`:
-
-- `climate`
-- `input_number`
-
-Even when the target source is called `input_number` in the UI, the integration accepts both `input_number.*` and `number.*` entities for that path.
+New zones start at `20.0` degrees Celsius. If the global or zone frost minimum is higher than `20.0`, that higher value becomes the initial zone target instead.
 
 ### Temperature Aggregation
 
@@ -263,7 +258,7 @@ data: {}
 
 Typical runtime usage is:
 
-1. Leave each zone target entity at its normal room target.
+1. Leave each zone target at its normal room target.
 2. Let the integration decide which zones currently demand heat.
 3. Use the system climate entity only when you want a temporary whole-system override.
 4. Use the global force-off switch when you want the whole system disabled without reconfiguring zones.
@@ -275,14 +270,14 @@ Typical runtime usage is:
 
 - Each room has one or more temperature sensors.
 - Each room has one or more climate TRV entities.
-- Each room target comes from a climate entity.
+- Each room target is owned by the integration.
 - The integration writes effective target temperatures to the TRVs and runs the shared boiler relay when any room demands heat.
 
 ### Example 2: Switch-Driven Zone Valves
 
 - Each zone has temperature sensors.
 - Each zone uses one or more switch-controlled valves.
-- Zone targets come from `input_number` helpers.
+- Zone targets are owned by the integration and shared across local groups.
 - The integration opens the right valves and enables the main relay only when needed.
 
 ### Example 3: Number-Driven Actuators
@@ -297,7 +292,7 @@ Version `0.2.0` is usable, but it is still an early release. Current limits to d
 
 - installation is documented as manual copy-based setup
 - the integration manages a single config entry for one heating system
-- target-source options are limited to `climate` and `input_number`
+- zone targets are stored by the integration instead of external helper or climate entities
 - dedicated `number` platform entities are not exposed yet, even though number actuators are supported
 - documentation screenshots are placeholders for now
 
@@ -312,7 +307,7 @@ Version `0.2.0` is usable, but it is still an early release. Current limits to d
 ### A Zone Never Calls For Heat
 
 - verify the zone is enabled
-- verify the target entity has a valid numeric target
+- verify the zone has a valid target temperature
 - verify the configured sensor entities have usable states
 - if using `primary` aggregation, confirm the chosen primary sensor is one of the configured sensors
 

--- a/docs/integration-design.md
+++ b/docs/integration-design.md
@@ -6,15 +6,15 @@ Design a custom Home Assistant integration that coordinates a multi-zone wet hea
 
 - One or more controllable valves per zone
 - One or more room temperature sensors per zone
-- One target temperature source per zone
+- One integration-managed virtual climate entity per zone
 - One shared relay that enables water flow for the full system
 
-The key control rule is straightforward:
+The key control rule remains:
 
-- If one or more zones require heat, open the main relay.
-- If no zones require heat, close the main relay.
+- If one or more zones require heat, open the main relay
+- If no zones require heat, close the main relay
 
-Zone valves are controlled independently according to each zone's temperature, target, and configuration.
+Zone actuators are controlled independently according to each zone's temperature, target, and configuration, but all zone targets are owned by this integration.
 
 ## Design Goals
 
@@ -23,8 +23,9 @@ Zone valves are controlled independently according to each zone's temperature, t
 - Keep control logic centralized and testable
 - Support a range of zone hardware capabilities
 - Prevent short-cycling and relay chatter
+- Remove subtle state drift between target sources and actuators
+- Fully adopt a master / slave control model
 - Provide diagnostics and override mechanisms
-- Make it easy to add or remove zones later
 
 ## Non-Goals
 
@@ -40,28 +41,21 @@ Zone valves are controlled independently according to each zone's temperature, t
 A zone is an independently controlled heated space. A zone has:
 
 - A name
+- One integration-owned virtual climate entity
 - One or more temperature sensors
-- A target temperature source
 - One or more control targets
-- Optional enable/disable state
+- Optional enable or disable state
 - Optional per-zone tuning values
 
-Each zone behaves as a logical grouping. For example, a large living area may have:
+The integration computes one demand state per zone.
 
-- Multiple temperature sensors across the space
-- Multiple thermostatic valves on separate radiators or local spots
+The zone climate entity is the master target interface for the zone. Every actuator in the zone is a slave:
 
-Zone-level sensors are primarily relevant for `climate` controlled zones.
+- Slave `climate` actuators receive target and HVAC commands from the coordinator
+- Slave `switch` actuators are turned on or off by the coordinator
+- Slave `number` actuators receive active and inactive values from the coordinator
 
-For `switch` and `number` controlled zones, sensing and actuation should usually be modeled through local control groups, where each group measures and controls its own local spot.
-
-The integration should compute one demand state for the zone.
-
-For `climate` control, all climate entities in the zone move together.
-
-For `switch` and `number` control, a zone may contain one or more local control groups. These groups represent local spots inside the room and pair local temperature measurement with local actuation, while still sharing the same zone target temperature.
-
-If a local spot needs its own target temperature, it should be modeled as a separate zone instead.
+Downstream actuator state never acts as the source of truth for zone targets.
 
 ### Local Control Group
 
@@ -73,9 +67,9 @@ Each local control group must have:
 - One or more actuator entities
 - One control type: `switch` or `number`
 
-The intent is that the actuators in the group primarily affect the measured temperature of that same local spot. In other words, a group is a paired sensor-and-actuator combination inside a shared zone.
+All groups in a zone share the same zone climate target temperature, but each group computes its own local demand from its own sensor set.
 
-All groups in a zone share the same target temperature, but each group computes its own local demand from its own sensor set.
+If a local spot needs its own target temperature, it should be modeled as a separate zone.
 
 ### Zone Temperature
 
@@ -83,30 +77,45 @@ Because a zone may contain multiple sensors, the integration needs a configurabl
 
 Supported aggregation modes:
 
-1. Average
+1. `average`
    Good general default when sensors represent the same space fairly well.
-2. Minimum
+2. `minimum`
    Useful when the coldest point in the zone should drive heating.
-3. Specific primary sensor
+3. `primary`
    Useful when one sensor should be authoritative and others are diagnostic only.
 
-Version 1 should support `average`, `minimum`, and `primary`.
+The zone virtual climate entity must expose `current_temperature` from this same aggregation logic:
+
+- `average` reports the mean of available configured zone sensors
+- `minimum` reports the lowest available configured zone sensor
+- `primary` reports the configured primary sensor directly
+
+If no valid sensor remains, the zone climate reports no `current_temperature` and the zone does not demand heat.
+
+### Zone Target Ownership
+
+Each zone target temperature is persisted in integration-owned state or config.
+
+Implications:
+
+- `target_source` and `target_entity_id` are removed from core zone configuration
+- A zone target is read from the zone virtual climate state only
+- Target changes made through the zone climate must survive restart
+- External Home Assistant entities may still automate the zone climate, but are not part of core zone config
 
 ### Zone Demand
 
 Zone demand is a computed boolean state indicating whether a zone currently requires heat.
 
-Suggested initial rule:
+Suggested rule:
 
-- Demand is `on` when `current_temperature < target_temperature - hysteresis_on`
-- Demand is `off` when `current_temperature > target_temperature + hysteresis_off`
+- Demand is `on` when `current_temperature < target_temperature - hysteresis`
+- Demand is `off` when `current_temperature >= target_temperature`
+- Otherwise retain prior demand state
 
-For the first version, symmetric hysteresis is likely enough:
+For `climate` controlled zones, this logic applies at zone level.
 
-- `demand on` below `target - hysteresis`
-- `demand off` above or equal to `target`
-
-This can be represented internally with stateful logic to avoid rapid toggling.
+For `switch` and `number` controlled zones, each local control group computes local demand from its own sensor set while sharing the zone target.
 
 ### System Demand
 
@@ -121,38 +130,18 @@ The main relay controls water flow to the heating system. It should be on only w
 
 ### Valve Strategy
 
-Different hardware may expose different control models. The integration should be designed to support at least these modes:
+Different hardware may expose different control models. The integration must support:
 
 1. Binary valve control
    A valve can be turned on or off directly.
-2. Target-based climate control
-   A climate entity can be driven by setting its HVAC mode or target temperature.
-3. Number-based valve target
-   A numeric entity can be set to a temperature or opening percentage.
+2. Slave climate control
+   A climate entity can be driven by setting HVAC mode or target temperature.
+3. Number-based control
+   A numeric entity can be set to a configured active or inactive value.
 
 Version 1 must support all three modes.
 
-Actuation behavior by control type:
-
-- `climate`
-  All climate entities in the zone should receive the same target temperature and move together.
-- `switch`
-  Local control groups may turn subsets of actuators on or off together.
-- `number`
-  Local control groups may write configured active or inactive values to subsets of actuators.
-
-For `number` entities, the configured meaning should be explicit:
-
-- Valve opening percentage
-- Temperature-like setpoint
-
 ## Recommended Architecture
-
-## Integration Domain
-
-- Domain: `multi_zone_heating`
-
-## Main Components
 
 ### Config Entry
 
@@ -162,6 +151,7 @@ Stores:
 - Optional flow meter entity ID
 - Global defaults
 - Zone definitions
+- Persisted zone target temperatures or references to owned stored state
 - Optional operating mode settings
 
 ### Options Flow
@@ -172,7 +162,7 @@ Allows changing:
 - Hysteresis defaults
 - Zone membership
 - Per-zone overrides
-- Override behavior
+- Per-zone target defaults when needed
 
 ### Runtime Coordinator
 
@@ -181,11 +171,12 @@ A central coordinator evaluates zone state and applies outputs.
 Responsibilities:
 
 - Track subscribed entity state changes
+- Compute aggregated zone temperatures
 - Compute zone demand
 - Compute aggregate demand
-- Apply valve commands
-- Apply main relay commands
-- Enforce minimum on/off timings
+- Read zone targets from integration-owned zone climate state only
+- Dispatch actuator and relay commands only when needed
+- Enforce minimum on and off timings
 - Publish diagnostics state
 
 ### Entity Layer
@@ -194,24 +185,25 @@ The integration should expose Home Assistant entities for visibility and control
 
 Recommended entities:
 
+- One virtual climate entity per zone
 - One binary sensor per zone for heat demand
 - One binary sensor for system heat demand
 - One top-level climate entity for the whole system
 - One sensor or enum for system control state
 - One switch for global relay force-off
-- One switch per zone for zone enable/disable
+- One switch per zone for zone enable or disable
 - Optional sensors for last action reason or last transition time
 
 ## Configuration Model
 
-## Global Configuration
+### Global Configuration
 
 Suggested initial global options:
 
 - Main relay entity
 - Optional numeric flow meter entity
 - Flow detection threshold
-- Poll/event debounce interval
+- Poll or event debounce interval
 - Default hysteresis
 - Minimum relay on time
 - Minimum relay off time
@@ -220,22 +212,20 @@ Suggested initial global options:
 - Global frost protection minimum
 - Failsafe mode
 
-## Per-Zone Configuration
+### Per-Zone Configuration
 
 Each zone should support:
 
 - Zone name
 - Enabled
-- Target source type
-- Target entity
 - Control type
-- Climate entities or local control groups
-- For `climate` zones: temperature sensor entities
+- For `climate` zones: zone-level sensors
+- For `climate` zones: slave climate entities
 - For `climate` zones: temperature aggregation mode
 - For `climate` zones: optional primary sensor
 - Optional per-zone frost protection minimum temperature
-- Optional low target temperature fallback for climate off behavior
-- Optional number inactive value configuration
+- Optional low target temperature fallback for slave climate off behavior
+- For `switch` and `number` zones: one or more local control groups
 
 Each local control group should support:
 
@@ -249,68 +239,45 @@ Each local control group should support:
 - For `number`, active value
 - For `number`, inactive value
 
-## Target Temperature Sources
-
-The design should support these possible target sources:
-
-1. Home Assistant `input_number`
-2. Home Assistant `climate` entity target temperature
-
-Version 1 should support both source types.
+Core zone config must not include `target_source` or `target_entity_id`.
 
 ## Control Algorithm
 
-## High-Level Loop
+### High-Level Loop
 
 Whenever a relevant entity changes:
 
-1. Read current temperature and target for each enabled zone
-2. Compute each zone demand with hysteresis
-3. Determine desired zone or local-group actuator state
-4. Determine desired system relay state
-5. Apply timing guards
-6. Write state changes only when needed
-7. Update diagnostic entities
+1. Read current sensor inputs and persisted zone targets
+2. Compute each zone's aggregated current temperature
+3. Compute each zone or local-group demand with hysteresis
+4. Determine desired slave actuator state
+5. Determine desired system relay state
+6. Apply timing guards
+7. Write state changes only when needed
+8. Update diagnostic entities
 
-## Suggested Zone Demand Logic
+### Suggested Zone Demand Logic
 
 Per zone:
 
 - If the zone is disabled, demand is off
-- If sensor or target data is unavailable, use configured failsafe behavior
+- If no valid sensor remains, demand is off
+- If no valid target remains, demand is off
 - Compute an effective zone temperature from the configured sensor set
-- If effective zone temperature is below `target - hysteresis`, demand becomes on
-- If effective zone temperature is at or above `target`, demand becomes off
-- Otherwise retain prior demand state
+- Compare against the integration-owned zone target
+- Retain prior demand state between on and off thresholds
 
-This state retention is important for stable behavior.
-
-Sensor availability handling:
-
-- Ignore unavailable sensors if one or more valid sensors remain
-- If no valid sensors remain in the zone, demand becomes off
-
-For `climate` controlled zones, this logic applies directly at the zone level.
-
-For `switch` and `number` controlled zones, each local control group computes its own effective temperature and local demand from its own sensor set. The zone is considered to have demand if one or more local groups have demand.
-
-## Suggested Relay Logic
+### Suggested Relay Logic
 
 - Relay desired state is on if any enabled zone demand is on
 - When changing to on, respect minimum off time
 - When changing to off, respect minimum on time and optional off delay
 - If a flow meter is configured, keep relay-off pending until flow drops
 
-Flow meter behavior in version 1:
-
-- Use it to delay relay-off until measured flow drops below the configured threshold
-- Raise a warning if there is demand but measured flow does not rise above the configured threshold after relay-on
-- Do not infer fault from unexpected flow with zero demand because domestic water heating shares the meter
-
-## Suggested Actuator Logic
+### Suggested Actuator Logic
 
 - `climate`
-  - When zone demand is on, set all climate entities in the zone to the zone target
+  - When zone demand is on, set all slave climate entities in the zone to the zone target
   - When zone demand is off, set HVAC mode to `off` where supported
   - If `off` is unavailable, set a configured low target temperature instead
 - `switch`
@@ -318,28 +285,7 @@ Flow meter behavior in version 1:
 - `number`
   - Each local control group writes its configured active value when heating and inactive value when not heating
 
-Switch and number local control groups should decide whether that local spot should be active from the group's own sensor set, while still sharing the zone target temperature.
-
-## Failure Handling
-
-Important decisions:
-
-- What happens if a sensor is unavailable?
-- What happens if a target source is unavailable?
-- What happens if the relay command fails?
-- What happens if a valve entity becomes unavailable?
-
-Recommended default approach:
-
-- Unavailable zone inputs disable demand for that zone and mark the zone as degraded
-- System relay stays off unless another healthy zone still calls for heat
-- Diagnostics should expose the degraded condition clearly
-- If one or more actuators in a zone are unavailable, continue heating while at least one actuator remains available
-- If no actuators remain available in a zone, that zone is failed for actuation
-
-An alternative optional mode could be:
-
-- Fail-safe heat retention for previously heating zones for a short grace period
+The coordinator reads zone targets from owned zone climate state, then dispatches to actuators only.
 
 ## Manual Overrides
 
@@ -347,14 +293,11 @@ The design should leave room for manual interventions.
 
 Possible override types:
 
-- Per-zone on or off
+- Per-zone enable or disable
 - Force system relay off
+- System-level master commands that fan out into zone-owned targets
 
-For version 1, global relay force-off should also disable downstream heat calls by:
-
-- Turning off switch actuators
-- Writing inactive values to number actuators
-- Setting climate HVAC mode to `off`, or a configured low target if `off` is unavailable
+Version 1 should avoid direct writes to external target sources and avoid mixed ownership.
 
 ## Diagnostics and Observability
 
@@ -363,10 +306,10 @@ Useful exposed states:
 - Zone effective temperature
 - Zone individual sensor temperatures
 - Zone target temperature
+- Zone climate current temperature
 - Zone demand
 - Zone reason for no demand
 - Local group effective temperature
-- Local group individual sensor temperatures
 - Local group demand
 - Zone actuator availability status
 - System demand
@@ -375,118 +318,52 @@ Useful exposed states:
 - Main flow value
 - Main flow detected state
 - Warning state for demand-without-flow
-- Last control action timestamp
-- Last control action reason
 
 Useful log events:
 
 - Zone demand changes
+- Zone target changes
 - Relay transitions
 - Suppressed relay transitions because of timing rules
 - Entity unavailability affecting control
-- Warning conditions such as demand present without detected flow
-
-## Proposed File Layout
-
-```text
-custom_components/
-  multi_zone_heating/
-    __init__.py
-    manifest.json
-    const.py
-    config_flow.py
-    coordinator.py
-    models.py
-    control_logic.py
-    binary_sensor.py
-    sensor.py
-    switch.py
-    climate.py
-    diagnostics.py
-    strings.json
-    translations/
-      en.json
-```
-
-## Internal Module Responsibilities
-
-- `const.py`
-  Domain constants, defaults, option keys
-- `models.py`
-  Dataclasses for config and runtime zone state
-- `control_logic.py`
-  Pure functions for demand and relay decisions
-- `coordinator.py`
-  Event subscriptions, state refresh, command dispatch
-- `config_flow.py`
-  Setup and options UI
-- `binary_sensor.py`
-  Zone demand and system demand entities
-- `sensor.py`
-  Diagnostic entities
-- `switch.py`
-  Enable and override switches
-- `climate.py`
-  Top-level system climate entity with global override target and HVAC mode
-- `diagnostics.py`
-  Structured diagnostic export
 
 ## Testing Strategy
-
-The design should support both pure logic testing and Home Assistant integration testing.
 
 Recommended initial tests:
 
 - Zone temperature aggregation behavior
+- Zone climate `current_temperature` for `average`, `minimum`, and `primary`
 - Zone demand hysteresis behavior
-- Primary sensor selection behavior
-- Local group temperature aggregation behavior
 - Local group demand behavior from local sensor sets
 - Group-level actuation for `switch` and `number`
-- Zone-wide synchronized actuation for `climate`
+- Zone-wide synchronized actuation for slave `climate` entities
 - Aggregate demand logic
 - Multi-actuator availability behavior
-- Minimum relay on/off time enforcement
+- Minimum relay on or off time enforcement
 - Relay off delayed by flow meter
 - Warning generation when demand exists without measured flow
 - Zone disable behavior
-- Unavailable sensor or target handling
-- Sensor loss leading to zone-off when no valid sensors remain
-- Correct entity state exposure
-- Config flow validation
-- Options flow updates
-
-## Open Design Decisions
-
-These are the main choices we should resolve before implementation:
-
-1. How should local control groups be represented in the config and options flow without making setup too heavy?
-2. Should frost protection support both global and per-zone minimums from the start?
-3. What secondary HVAC modes, if any, should the top-level climate entity expose beyond `heat` and `off`?
+- Persisted zone target restore across restart
+- Config migration away from `target_source` and `target_entity_id`
 
 ## Recommended Version 1 Scope
-
-To keep the first implementation manageable:
 
 - Support one main relay `switch` or `input_boolean`
 - Support one optional numeric flow meter and configurable detection threshold
 - Support multiple zones
-- Support one or more temperature sensors per zone
+- Support one virtual climate entity per zone
+- Support integration-owned persistence of zone targets
 - Support configurable zone temperature aggregation: `average`, `minimum`, `primary`
-- Support one target temperature source per zone from `input_number` or `climate`
 - Support `switch`, `climate`, and `number` control types
-- Support zone-wide climate actuation
+- Support zone-wide slave climate actuation
 - Support local control groups for `switch` and `number`
-- Require local control groups to include both sensors and actuators
-- Support configurable number semantics and inactive values
 - Support symmetric hysteresis
-- Support minimum relay on/off times and off delay
+- Support minimum relay on or off times and off delay
 - Support relay-off delay until flow drops
 - Support warning state when there is demand without measured flow
 - Support a top-level climate entity
-- Support frost protection in version 1
 - Expose zone demand and system demand binary sensors
-- Expose per-zone enable/disable
+- Expose per-zone enable or disable
 - Expose global relay force-off
 - Use config flow and options flow
 
@@ -497,7 +374,7 @@ The integration should expose one system-level climate entity.
 Version 1 behavior:
 
 - `target_temperature`
-  Acts as a global override target temperature and overrides all zone targets while active.
+  Acts as a master command surface for the system.
 - `hvac_mode`
   Supports `heat` and `off`.
 - `off`
@@ -505,27 +382,15 @@ Version 1 behavior:
 - `heat`
   Clears global force-off and resumes normal zone control.
 
-Global override behavior:
+Master / slave behavior:
 
-- Setting `target_temperature` creates or updates a global override target
-- The global override applies to all zones and local groups
-- The global override remains active until:
-  - A zone target changes, or
-  - A dedicated `clear_override` action is invoked
-- Original per-zone targets are preserved and automatically reused once the override ends
-- If `hvac_mode` is `off`, the override target and override state are preserved
-- If `target_temperature` is changed while `hvac_mode` is `off`, the override is stored but heating remains off until `hvac_mode` returns to `heat`
-
-Entity presentation:
-
-- When override is active, the climate entity target temperature reflects the active global override
-- When override is not active, there is no meaningful system target temperature
-- For Home Assistant compatibility, the entity may retain the last override target as its displayed target value while exposing whether it is active through attributes
+- Setting a zone climate target updates that zone's persisted target
+- The coordinator reads zone targets from zone climate state only
+- Downstream actuators never provide target input
+- Setting the system climate target may fan out to zone climates, but zone climates remain the only per-zone source of truth
 
 Recommended attributes:
 
-- `override_active`
-- `override_target_temperature`
 - `zones_calling_for_heat`
 - `global_force_off`
 
@@ -535,6 +400,6 @@ Refine the version 1 scope into a concrete schema:
 
 - Supported entity domains
 - Config entry structure
-- Zone options schema
-- Exact entity set to expose
+- Zone target persistence model
+- Zone climate restore-state behavior
 - Detailed state machine for demand and relay control

--- a/docs/integration-design.md
+++ b/docs/integration-design.md
@@ -51,11 +51,12 @@ The integration computes one demand state per zone.
 
 The zone climate entity is the master target interface for the zone. Every actuator in the zone is a slave:
 
-- Slave `climate` actuators receive target and HVAC commands from the coordinator
+- Slave `climate` actuators receive target commands from the coordinator and follow the virtual zone or system master for HVAC mode
 - Slave `switch` actuators are turned on or off by the coordinator
 - Slave `number` actuators receive active and inactive values from the coordinator
 
 Downstream actuator state never acts as the source of truth for zone targets.
+For climate zones, demand affects relay and idle or heating state, but not whether the slave thermostat stays in `heat` or `off`.
 
 ### Local Control Group
 
@@ -277,9 +278,11 @@ Per zone:
 ### Suggested Actuator Logic
 
 - `climate`
-  - When zone demand is on, set all slave climate entities in the zone to the zone target
-  - When zone demand is off, set HVAC mode to `off` where supported
-  - If `off` is unavailable, set a configured low target temperature instead
+  - When a zone is enabled and not globally forced off, keep supported slave climate entities in `heat`
+  - While a zone is enabled, set all slave climate entities in the zone to the zone target
+  - When zone demand is off, the zone may be idle but slave climates do not switch `off` only because demand cleared
+  - When a zone is disabled or global force-off is active, set HVAC mode to `off` where supported
+  - If `off` is unavailable, set a configured low target temperature instead when the zone is disabled or globally forced off
 - `switch`
   - Each local control group turns all of its actuators on or off together
 - `number`
@@ -337,6 +340,7 @@ Recommended initial tests:
 - Local group demand behavior from local sensor sets
 - Group-level actuation for `switch` and `number`
 - Zone-wide synchronized actuation for slave `climate` entities
+- Slave climate HVAC mode following virtual zone `heat` or `off` instead of demand transitions
 - Aggregate demand logic
 - Multi-actuator availability behavior
 - Minimum relay on or off time enforcement
@@ -385,6 +389,7 @@ Version 1 behavior:
 Master / slave behavior:
 
 - Setting a zone climate target updates that zone's persisted target
+- Setting a zone climate HVAC mode to `off` disables that zone and `heat` enables it
 - The coordinator reads zone targets from zone climate state only
 - Downstream actuators never provide target input
 - Setting the system climate target may fan out to zone climates, but zone climates remain the only per-zone source of truth

--- a/docs/issues/ISSUE-012-zone-target-ownership-and-migration.md
+++ b/docs/issues/ISSUE-012-zone-target-ownership-and-migration.md
@@ -1,0 +1,39 @@
+# ISSUE-012 Zone Target Ownership And Migration
+
+## Goal
+
+Replace external zone target configuration with integration-owned zone target state and migrate existing entries safely.
+
+## Scope
+
+- Remove `target_source` and `target_entity_id` from core zone schema
+- Update config flow and options flow to stop asking for target entities
+- Add config-entry migration for older entries
+- Define how initial zone target defaults are created
+- Update translations and validation rules
+
+## Why
+
+The current target-entity model creates split ownership and subtle state drift. Zone targets must be owned by the integration to support a strict master / slave design.
+
+## Related Stories
+
+- US-002
+- US-005
+- US-024
+
+## Acceptance Criteria
+
+- New zones can be created without `target_source` or `target_entity_id`
+- Existing entries are migrated or rejected with a clear user-visible reason
+- The resulting config model is consistent across setup, options, diagnostics, and tests
+- Migration behavior is documented in the repo
+
+## Dependencies
+
+- ISSUE-001
+
+## Out Of Scope
+
+- Runtime slave actuator dispatch
+- Zone climate entity implementation

--- a/docs/issues/ISSUE-012-zone-target-ownership-and-migration.md
+++ b/docs/issues/ISSUE-012-zone-target-ownership-and-migration.md
@@ -29,6 +29,13 @@ The current target-entity model creates split ownership and subtle state drift. 
 - The resulting config model is consistent across setup, options, diagnostics, and tests
 - Migration behavior is documented in the repo
 
+## Migration Notes
+
+- New zones start with an integration-owned target of `20.0` C
+- If a global or zone frost minimum is higher than `20.0` C, that higher value becomes the initial target
+- Existing entries migrate by reading the current target from the old external target entity at migration time
+- If the old target entity has no usable current target state, migration fails so the entry is not silently changed
+
 ## Dependencies
 
 - ISSUE-001

--- a/docs/issues/ISSUE-013-zone-virtual-climate-entities.md
+++ b/docs/issues/ISSUE-013-zone-virtual-climate-entities.md
@@ -1,0 +1,40 @@
+# ISSUE-013 Zone Virtual Climate Entities
+
+## Goal
+
+Add one virtual climate entity per zone and make it the authoritative interface for zone targets.
+
+## Scope
+
+- Extend `climate.py` with one climate entity per zone
+- Expose zone target temperature through the zone climate
+- Persist and restore zone target temperature in integration-owned state
+- Expose zone `current_temperature` from zone aggregation logic
+- Support `average`, `minimum`, and `primary` presentation rules
+
+## Why
+
+Each zone needs a single master entity that represents both the target and the actual measured zone temperature used by the coordinator.
+
+## Related Stories
+
+- US-005
+- US-008
+- US-020
+
+## Acceptance Criteria
+
+- The integration exposes one climate entity per configured zone
+- Setting a zone climate target updates the persisted zone-owned target
+- Restart restores the last zone target
+- Zone climate `current_temperature` reflects the configured aggregation mode
+- `primary` uses the configured primary sensor directly
+
+## Dependencies
+
+- ISSUE-012
+
+## Out Of Scope
+
+- Top-level climate behavior redesign
+- Relay logic

--- a/docs/issues/ISSUE-014-coordinator-master-slave-dispatch.md
+++ b/docs/issues/ISSUE-014-coordinator-master-slave-dispatch.md
@@ -1,0 +1,44 @@
+# ISSUE-014 Coordinator Master Slave Dispatch
+
+## Goal
+
+Update the runtime coordinator so zone targets come only from integration-owned zone climate state and all actuators behave as slaves.
+
+## Scope
+
+- Remove coordinator reads from external zone target entities
+- Read zone targets from owned zone climate state only
+- Keep zone and local-group demand evaluation working with the new target model
+- Dispatch commands to slave `climate`, `switch`, and `number` actuators only
+- Ensure command deduplication and availability handling remain correct
+
+## Why
+
+The coordinator is where split ownership currently becomes runtime drift. This issue makes the master / slave model real.
+
+## Related Stories
+
+- US-006
+- US-007
+- US-010
+- US-011
+- US-012
+- US-013
+
+## Acceptance Criteria
+
+- The coordinator no longer depends on `target_source` or `target_entity_id`
+- Zone demand uses the persisted zone-owned target
+- Slave climate actuators never act as target sources
+- Switch and number groups still share the same zone target
+- Commands are only sent when required
+
+## Dependencies
+
+- ISSUE-012
+- ISSUE-013
+
+## Out Of Scope
+
+- Config flow migration
+- Top-level climate UX details

--- a/docs/issues/ISSUE-015-system-climate-diagnostics-and-tests.md
+++ b/docs/issues/ISSUE-015-system-climate-diagnostics-and-tests.md
@@ -1,0 +1,41 @@
+# ISSUE-015 System Climate Diagnostics And Tests
+
+## Goal
+
+Align the system climate, diagnostics, and tests with the zone-owned climate model.
+
+## Scope
+
+- Redefine top-level climate semantics so they do not reintroduce external target ownership
+- Update diagnostics to report zone climate state and owned targets
+- Update or remove stale global-override assumptions where needed
+- Add and update tests for migration, zone climate restore state, aggregated `current_temperature`, and master / slave dispatch
+
+## Why
+
+The redesign is incomplete unless the system climate surface, diagnostics, and tests reflect the new ownership model.
+
+## Related Stories
+
+- US-019
+- US-020
+- US-021
+- US-024
+- US-025
+
+## Acceptance Criteria
+
+- The top-level climate behavior is documented and tested against the new model
+- Diagnostics expose zone climate target and temperature information
+- Tests cover `average`, `minimum`, and `primary` zone climate temperatures
+- Tests cover migration away from target entities
+- No remaining documentation or tests rely on old target-source behavior without an explicit reason
+
+## Dependencies
+
+- ISSUE-013
+- ISSUE-014
+
+## Out Of Scope
+
+- New hardware control types

--- a/docs/issues/ISSUE-016-climate-slave-hvac-follows-virtual-zone-master.md
+++ b/docs/issues/ISSUE-016-climate-slave-hvac-follows-virtual-zone-master.md
@@ -1,0 +1,45 @@
+# ISSUE-016 Climate Slave HVAC Follows Virtual Zone Master
+
+## Goal
+
+Change climate-zone runtime dispatch so slave climate entities follow the virtual zone master for HVAC mode instead of switching `heat` or `off` on demand transitions.
+
+## Scope
+
+- Update `coordinator.py` climate-zone dispatch rules
+- Keep slave climate entities in `heat` while the zone is enabled and global force-off is inactive
+- Continue synchronizing slave climate target temperatures from the zone-owned target
+- Stop turning slave climate entities `off` only because demand cleared
+- Turn slave climate entities `off` only when the zone is disabled or global force-off is active
+- Use the configured fallback target only when `off` is unsupported and the zone is disabled or globally forced off
+
+## Why
+
+The current implementation still treats slave climate entities like demand-switched actuators. That breaks the intended virtual-master model because the slave thermostat should keep its own setpoint logic active while the virtual zone decides whether the system is heating or idle.
+
+## Related Stories
+
+- US-010
+- US-017
+- US-018
+- US-020
+- US-021
+
+## Acceptance Criteria
+
+- When a climate zone is enabled and not globally forced off, slave climate entities are kept in `heat` where supported
+- When zone demand clears, slave climate entities do not switch to `off` solely because demand became false
+- When a climate zone is disabled, slave climate entities are set to `off` where supported
+- When global force-off is active, slave climate entities are set to `off` where supported
+- When `off` is unsupported, fallback target behavior is applied only for zone-disable or global-force-off cases
+- Relay demand behavior remains based on zone demand rather than slave climate HVAC mode
+
+## Dependencies
+
+- ISSUE-014
+- ISSUE-015
+
+## Out Of Scope
+
+- Config-flow changes
+- New climate control types

--- a/docs/issues/ISSUE-017-zone-hvac-surface-and-regression-alignment.md
+++ b/docs/issues/ISSUE-017-zone-hvac-surface-and-regression-alignment.md
@@ -1,0 +1,41 @@
+# ISSUE-017 Zone HVAC Surface And Regression Alignment
+
+## Goal
+
+Align entity surfaces, diagnostics, and regression coverage around the rule that zone `hvac_mode` represents zone enable or disable while slave climate HVAC mode follows that master state.
+
+## Scope
+
+- Add coordinator and entity tests for zone climate `heat` or `off` behavior
+- Add tests that cover slave climate behavior for enabled, disabled, and global-force-off states
+- Verify the zone-enabled switch and zone climate `hvac_mode` stay synchronized through shared zone state
+- Update diagnostics where needed so `hvac_mode`, `hvac_action`, and demand are reported consistently
+
+## Why
+
+The behavior spans more than one surface. If tests and diagnostics keep the old demand-driven assumptions, the code can drift back into the wrong model even after the coordinator is fixed.
+
+## Related Stories
+
+- US-017
+- US-018
+- US-019
+- US-020
+- US-021
+
+## Acceptance Criteria
+
+- Setting zone climate `hvac_mode` to `off` disables the zone and updates downstream slave climate behavior
+- Setting zone climate `hvac_mode` to `heat` re-enables the zone and restores normal slave climate master-following behavior
+- The zone-enabled switch reflects the same enabled state as the zone climate `hvac_mode`
+- Diagnostics distinguish zone disabled state from zone idle demand state
+- Tests no longer expect slave climate entities to switch `off` when demand merely clears
+
+## Dependencies
+
+- ISSUE-016
+
+## Out Of Scope
+
+- Replacing the zone-enabled switch surface
+- Redesigning the system climate entity

--- a/docs/user-stories.md
+++ b/docs/user-stories.md
@@ -44,14 +44,15 @@ Acceptance criteria:
 
 - A zone has a name
 - A zone can be enabled or disabled
-- A zone has one target temperature source
+- A zone has one integration-owned virtual climate entity
 - A zone has one control type: `climate`, `switch`, or `number`
 - Zones can be added and edited through the UI
+- Core zone config does not require `target_source` or `target_entity_id`
 
 #### US-003 Configure a climate-controlled zone
 
 As a home owner,
-I want to configure a zone that is controlled through one or more climate entities,
+I want to configure a zone that is controlled through one or more slave climate entities,
 so that all climate devices in that zone act together.
 
 Acceptance criteria:
@@ -59,8 +60,8 @@ Acceptance criteria:
 - A climate zone can have one or more temperature sensors
 - A climate zone supports temperature aggregation modes `average`, `minimum`, and `primary`
 - A climate zone can define a primary sensor when using `primary`
-- A climate zone can contain one or more climate entities
-- All climate entities in the zone share the same zone target temperature
+- A climate zone can contain one or more slave climate entities
+- The zone virtual climate is the only source of truth for the zone target temperature
 
 #### US-004 Configure local control groups for switch and number zones
 
@@ -75,19 +76,20 @@ Acceptance criteria:
 - Each local control group must contain one or more actuators
 - Each local control group has one control type: `switch` or `number`
 - Each local control group can be named
-- All local control groups in the same zone share the same target temperature source
+- All local control groups in the same zone share the zone climate target temperature
 
-#### US-005 Use Home Assistant entities as target temperature sources
+#### US-005 Persist zone target temperatures in integration-owned state
 
 As a home owner,
-I want zone targets to come from Home Assistant entities I already use,
-so that the heating integration fits into my existing setup.
+I want each zone target temperature to be stored by the integration itself,
+so that target state is stable and survives restart without depending on external entities.
 
 Acceptance criteria:
 
-- A zone target can come from an `input_number`
-- A zone target can come from a `climate` entity target temperature
-- Target temperature changes are reflected in control decisions without restart
+- Each zone target temperature is stored in integration-owned state or config
+- A restart restores the last persisted zone target temperature
+- Zone control decisions use the restored value without waiting on an external target entity
+- External Home Assistant automations can change a zone by calling the zone climate entity
 
 ### Temperature and Demand Logic
 
@@ -113,11 +115,25 @@ so that each local spot can be heated according to its measured temperature.
 Acceptance criteria:
 
 - Each local control group computes its own effective temperature
-- Each local control group uses the shared zone target temperature
+- Each local control group uses the shared zone target temperature from the zone climate
 - Each local control group applies the global hysteresis
 - A zone is considered to have demand if one or more local groups have demand
 
-#### US-008 Handle unavailable sensors safely
+#### US-008 Expose zone climate current temperature from aggregation logic
+
+As a home owner,
+I want the zone virtual climate to show the actual zone temperature,
+so that the UI reflects the same temperature the integration uses for control.
+
+Acceptance criteria:
+
+- The zone climate exposes `current_temperature`
+- For `average`, `current_temperature` is the mean of available configured zone sensors
+- For `minimum`, `current_temperature` is the minimum of available configured zone sensors
+- For `primary`, `current_temperature` is the configured primary sensor value
+- If no valid sensor remains, `current_temperature` is unavailable or `None`
+
+#### US-009 Handle unavailable sensors safely
 
 As a home owner,
 I want the system to behave safely when sensors become unavailable,
@@ -132,19 +148,20 @@ Acceptance criteria:
 
 ### Actuator Control
 
-#### US-009 Control climate entities together within a zone
+#### US-010 Control slave climate entities together within a zone
 
 As a home owner,
-I want all climate entities in a climate-controlled zone to move together,
+I want all slave climate entities in a climate-controlled zone to move together,
 so that the zone behaves as one heating area.
 
 Acceptance criteria:
 
-- When a climate zone demands heat, all climate entities in the zone are driven to the zone target
-- When a climate zone no longer demands heat, climate entities are set to HVAC mode `off` where supported
+- When a climate zone demands heat, all slave climate entities in the zone are driven to the zone target
+- When a climate zone no longer demands heat, slave climate entities are set to HVAC mode `off` where supported
 - If a climate entity does not support `off`, a configured low target temperature is used instead
+- Slave climate entities do not provide the source of truth for the zone target
 
-#### US-010 Control switch local groups independently
+#### US-011 Control switch local groups independently
 
 As a home owner,
 I want each switch-based local control group to turn its own valves on or off,
@@ -156,7 +173,7 @@ Acceptance criteria:
 - When a switch group no longer demands heat, all switch actuators in that group are turned off
 - Different groups in the same zone can be on or off independently
 
-#### US-011 Control number local groups independently
+#### US-012 Control number local groups independently
 
 As a home owner,
 I want each number-based local control group to write active and inactive values,
@@ -170,7 +187,7 @@ Acceptance criteria:
 - When a number group no longer demands heat, the inactive value is written
 - Different groups in the same zone can be active or inactive independently
 
-#### US-012 Continue operating while at least one actuator remains available
+#### US-013 Continue operating while at least one actuator remains available
 
 As a home owner,
 I want heating to continue if some actuators fail but others remain available,
@@ -184,7 +201,7 @@ Acceptance criteria:
 
 ### Main Relay and Flow Control
 
-#### US-013 Turn on the main relay when any zone needs heat
+#### US-014 Turn on the main relay when any zone needs heat
 
 As a home owner,
 I want the main relay to turn on whenever the system requires heat,
@@ -196,7 +213,7 @@ Acceptance criteria:
 - The relay on command respects the configured minimum off time
 - Relay state is exposed in diagnostics
 
-#### US-014 Turn off the main relay only after heating demand ends and flow drops
+#### US-015 Turn off the main relay only after heating demand ends and flow drops
 
 As a home owner,
 I want the relay to stay on briefly and wait for flow to drop,
@@ -209,7 +226,7 @@ Acceptance criteria:
 - If a flow meter is configured, relay off remains pending until flow is no longer detected
 - If no flow meter is configured, relay off uses timing rules only
 
-#### US-015 Warn when there is heating demand but no detected flow
+#### US-016 Warn when there is heating demand but no detected flow
 
 As a home owner,
 I want the integration to raise a warning if the system calls for heat but no flow is detected,
@@ -224,7 +241,7 @@ Acceptance criteria:
 
 ### Overrides and User-Facing Entities
 
-#### US-016 Disable a zone manually
+#### US-017 Disable a zone manually
 
 As a home owner,
 I want to turn a zone on or off manually,
@@ -234,9 +251,9 @@ Acceptance criteria:
 
 - Each zone exposes an enable or disable control
 - A disabled zone does not generate demand
-- Disabling a zone updates group or climate actuation accordingly
+- Disabling a zone updates downstream actuation accordingly
 
-#### US-017 Force all heating off globally
+#### US-018 Force all heating off globally
 
 As a home owner,
 I want to force the whole heating system off,
@@ -248,9 +265,9 @@ Acceptance criteria:
 - While global force-off is active, the main relay is kept off
 - While global force-off is active, switch actuators are turned off
 - While global force-off is active, number actuators are set to inactive values
-- While global force-off is active, climate entities are set to `off` or low-target fallback
+- While global force-off is active, climate actuators are set to `off` or low-target fallback
 
-#### US-018 Expose zone and system demand entities
+#### US-019 Expose zone and system demand entities
 
 As a Home Assistant automation author,
 I want demand and status entities exposed by the integration,
@@ -263,7 +280,20 @@ Acceptance criteria:
 - The system exposes relay desired and actual state information
 - Diagnostics expose sensor and actuator availability information
 
-#### US-019 Expose a top-level climate entity
+#### US-020 Expose a zone climate entity per zone
+
+As a home owner,
+I want each zone to have its own climate entity,
+so that I can control zone targets through a native Home Assistant climate surface.
+
+Acceptance criteria:
+
+- The integration exposes one climate entity per zone
+- Setting zone target temperature updates the integration-owned persisted target
+- The zone climate shows `current_temperature` from the configured zone aggregation logic
+- The zone climate does not proxy another entity as its target source
+
+#### US-021 Expose a top-level climate entity
 
 As a home owner,
 I want a top-level climate entity for the heating system,
@@ -274,17 +304,12 @@ Acceptance criteria:
 - The integration exposes one system-level climate entity
 - The entity reflects overall heating availability and state
 - The entity supports turning the heating system off
-- The entity exposes a global override target temperature
 - Setting HVAC mode to `off` activates global force-off
 - Setting HVAC mode to `heat` clears global force-off
-- Setting target temperature creates or updates a global override
-- The override remains active until a zone target changes or a `clear_override` action is used
-- The original per-zone targets are preserved and restored when the override ends
-- If HVAC mode is `off`, override state and override target are preserved
-- If target temperature is changed while HVAC mode is `off`, the override is stored without resuming heating
-- The climate entity exposes attributes for `override_active`, `override_target_temperature`, `zones_calling_for_heat`, and `global_force_off`
+- If the entity exposes target temperature, writing it fans out through integration-owned zone targets rather than external target entities
+- The climate entity exposes attributes for `zones_calling_for_heat` and `global_force_off`
 
-#### US-020 Support a global frost protection minimum
+#### US-022 Support a global frost protection minimum
 
 As a home owner,
 I want a minimum heating safeguard,
@@ -295,7 +320,7 @@ Acceptance criteria:
 - A global minimum temperature can be configured
 - The integration prevents effective target temperature from falling below that minimum
 
-#### US-021 Support per-zone frost protection minimums
+#### US-023 Support per-zone frost protection minimums
 
 As a home owner,
 I want some zones to have their own minimum temperatures,
@@ -306,9 +331,21 @@ Acceptance criteria:
 - A zone can override the global minimum temperature
 - Zone-specific minimums are used in demand calculations for that zone
 
+#### US-024 Migrate existing configurations away from target entities
+
+As an existing user,
+I want the integration to migrate old zone target configuration safely,
+so that the redesign does not break my installation unexpectedly.
+
+Acceptance criteria:
+
+- Existing configs using `target_source` or `target_entity_id` are migrated or rejected clearly
+- Migration behavior is documented
+- Tests cover migrated config entries
+
 ## Should-Have Stories
 
-#### US-022 Expose detailed diagnostics for each local group
+#### US-025 Expose detailed diagnostics for each local group
 
 As a home owner,
 I want to inspect local group temperatures and demand,
@@ -321,7 +358,7 @@ Acceptance criteria:
 - Local group sensor availability is exposed
 - Local group actuator availability is exposed
 
-#### US-023 Keep configuration editable through an options flow
+#### US-026 Keep configuration editable through an options flow
 
 As a home owner,
 I want to adjust system settings after setup,
@@ -337,31 +374,25 @@ Acceptance criteria:
 
 ## Later Stories
 
-#### US-024 Detect open windows from zone disable patterns
+#### US-027 Detect open windows from zone disable patterns
 
 As a home owner,
 I want the integration to support smarter zone disable behavior,
 so that open-window logic can be added later.
 
-#### US-025 Provide richer fault entities and repair flows
+#### US-028 Provide richer fault entities and repair flows
 
 As a home owner,
 I want clearer fault reporting and recovery guidance,
 so that I can diagnose failed sensors, failed actuators, and flow issues more easily.
 
-#### US-026 Auto-suggest entities during setup
+#### US-029 Auto-suggest entities during setup
 
 As an installer,
 I want the integration to suggest likely matching sensors and actuators,
 so that large systems are faster to configure.
 
-#### US-027 Support numeric flow sensors with thresholds
-
-As a home owner,
-I want to use a numeric flow meter with a configurable threshold,
-so that flow detection works with more hardware types.
-
-#### US-028 Add richer top-level climate behavior
+#### US-030 Add richer top-level climate behavior
 
 As a home owner,
 I want the top-level climate entity to support a well-defined target and mode model,
@@ -375,6 +406,8 @@ The smallest coherent version 1 should include:
 - Main relay control
 - Optional numeric flow meter support with thresholding
 - Zone definitions
+- One virtual climate entity per zone
+- Integration-owned persistence of zone targets
 - Climate-controlled zones
 - Switch and number local control groups
 - Demand calculation with global hysteresis
@@ -382,11 +415,5 @@ The smallest coherent version 1 should include:
 - Per-zone enable or disable
 - Global force-off
 - Zone and system demand entities
-- Top-level climate entity with global override target and `heat`/`off`
+- Top-level climate entity
 - Warning state for demand without flow
-
-## Open Questions Before Implementation
-
-These stories are ready enough to guide implementation, but a few product details still need a final decision:
-
-1. How should local control groups be edited in the options flow without becoming cumbersome?

--- a/docs/user-stories.md
+++ b/docs/user-stories.md
@@ -156,9 +156,11 @@ so that the zone behaves as one heating area.
 
 Acceptance criteria:
 
-- When a climate zone demands heat, all slave climate entities in the zone are driven to the zone target
-- When a climate zone no longer demands heat, slave climate entities are set to HVAC mode `off` where supported
-- If a climate entity does not support `off`, a configured low target temperature is used instead
+- While a climate zone is enabled, all slave climate entities in the zone are driven to the zone target
+- Slave climate entities follow the virtual zone master for HVAC mode rather than switching `heat` or `off` on every demand transition
+- When a climate zone no longer demands heat, slave climate entities may remain in `heat` while the relay and zone demand logic go idle
+- When a zone is disabled or global force-off is active, slave climate entities are set to HVAC mode `off` where supported
+- If a climate entity does not support `off`, a configured low target temperature is used instead when the zone is disabled or globally forced off
 - Slave climate entities do not provide the source of truth for the zone target
 
 #### US-011 Control switch local groups independently
@@ -250,6 +252,8 @@ so that I can temporarily disable heating in that zone.
 Acceptance criteria:
 
 - Each zone exposes an enable or disable control
+- The zone climate `hvac_mode` is an authoritative `heat` or `off` control for that zone
+- Any additional zone enable surface stays synchronized with the zone climate `hvac_mode`
 - A disabled zone does not generate demand
 - Disabling a zone updates downstream actuation accordingly
 
@@ -291,6 +295,7 @@ Acceptance criteria:
 - The integration exposes one climate entity per zone
 - Setting zone target temperature updates the integration-owned persisted target
 - The zone climate shows `current_temperature` from the configured zone aggregation logic
+- The zone climate uses `hvac_mode` `heat` and `off` to represent whether the zone is enabled
 - The zone climate does not proxy another entity as its target source
 
 #### US-021 Expose a top-level climate entity

--- a/tests/components/multi_zone_heating/test_config_flow.py
+++ b/tests/components/multi_zone_heating/test_config_flow.py
@@ -5,7 +5,11 @@ from __future__ import annotations
 from homeassistant import config_entries, data_entry_flow
 from homeassistant.const import CONF_NAME
 
-from custom_components.multi_zone_heating.const import DEFAULT_TITLE, DOMAIN
+from custom_components.multi_zone_heating.const import (
+    DEFAULT_TITLE,
+    DEFAULT_ZONE_TARGET_TEMPERATURE,
+    DOMAIN,
+)
 from custom_components.multi_zone_heating.config_flow import (
     ACTION_ADD_GROUP,
     ACTION_ADD_ZONE,
@@ -37,8 +41,7 @@ from custom_components.multi_zone_heating.config_flow import (
     CONF_PRIMARY_SENSOR_ENTITY_ID,
     CONF_RELAY_OFF_DELAY_SECONDS,
     CONF_SENSOR_ENTITY_IDS,
-    CONF_TARGET_ENTITY_ID,
-    CONF_TARGET_SOURCE,
+    CONF_TARGET_TEMPERATURE,
     CONF_ZONE,
     CONF_ZONES,
     CONF_GROUP,
@@ -47,7 +50,6 @@ from custom_components.multi_zone_heating.models import (
     AggregationMode,
     ControlType,
     NumberSemanticType,
-    TargetSourceType,
 )
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
@@ -87,8 +89,7 @@ def _existing_config() -> dict[str, object]:
                 CONF_NAME: "Bedroom",
                 CONF_ENABLED: True,
                 CONF_CONTROL_TYPE: ControlType.SWITCH,
-                CONF_TARGET_SOURCE: TargetSourceType.INPUT_NUMBER,
-                CONF_TARGET_ENTITY_ID: "input_number.bedroom_target",
+                CONF_TARGET_TEMPERATURE: DEFAULT_ZONE_TARGET_TEMPERATURE,
                 CONF_FROST_PROTECTION_MIN_TEMP: None,
                 CONF_SENSOR_ENTITY_IDS: [],
                 CONF_CLIMATE_ENTITY_IDS: [],
@@ -172,8 +173,6 @@ async def test_user_flow_creates_entry_for_climate_zone(hass) -> None:
             CONF_NAME: "Living Room",
             CONF_ENABLED: True,
             CONF_CONTROL_TYPE: ControlType.CLIMATE,
-            CONF_TARGET_SOURCE: TargetSourceType.CLIMATE,
-            CONF_TARGET_ENTITY_ID: "climate.living_room_target",
             CONF_FROST_PROTECTION_MIN_TEMP: 8.0,
         },
     )
@@ -217,8 +216,7 @@ async def test_user_flow_creates_entry_for_climate_zone(hass) -> None:
                 CONF_NAME: "Living Room",
                 CONF_ENABLED: True,
                 CONF_CONTROL_TYPE: ControlType.CLIMATE,
-                CONF_TARGET_SOURCE: TargetSourceType.CLIMATE,
-                CONF_TARGET_ENTITY_ID: "climate.living_room_target",
+                CONF_TARGET_TEMPERATURE: 20.0,
                 CONF_FROST_PROTECTION_MIN_TEMP: 8.0,
                 CONF_SENSOR_ENTITY_IDS: ["sensor.living_room_temperature"],
                 CONF_CLIMATE_ENTITY_IDS: ["climate.living_room_radiator"],
@@ -256,8 +254,6 @@ async def test_user_flow_creates_entry_for_switch_zone_with_local_group(hass) ->
             CONF_NAME: "Bedroom",
             CONF_ENABLED: True,
             CONF_CONTROL_TYPE: ControlType.SWITCH,
-            CONF_TARGET_SOURCE: TargetSourceType.INPUT_NUMBER,
-            CONF_TARGET_ENTITY_ID: "input_number.bedroom_target",
         },
     )
 
@@ -297,8 +293,7 @@ async def test_user_flow_creates_entry_for_switch_zone_with_local_group(hass) ->
             CONF_NAME: "Bedroom",
             CONF_ENABLED: True,
             CONF_CONTROL_TYPE: ControlType.SWITCH,
-            CONF_TARGET_SOURCE: TargetSourceType.INPUT_NUMBER,
-            CONF_TARGET_ENTITY_ID: "input_number.bedroom_target",
+            CONF_TARGET_TEMPERATURE: DEFAULT_ZONE_TARGET_TEMPERATURE,
             CONF_FROST_PROTECTION_MIN_TEMP: None,
             CONF_SENSOR_ENTITY_IDS: [],
             CONF_CLIMATE_ENTITY_IDS: [],
@@ -331,8 +326,6 @@ async def test_user_flow_supports_multiple_zones_and_multiple_local_groups(hass)
             CONF_NAME: "Upstairs",
             CONF_ENABLED: True,
             CONF_CONTROL_TYPE: ControlType.SWITCH,
-            CONF_TARGET_SOURCE: TargetSourceType.INPUT_NUMBER,
-            CONF_TARGET_ENTITY_ID: "input_number.upstairs_target",
         },
     )
 
@@ -389,8 +382,6 @@ async def test_user_flow_supports_multiple_zones_and_multiple_local_groups(hass)
             CONF_NAME: "Living Room",
             CONF_ENABLED: True,
             CONF_CONTROL_TYPE: ControlType.CLIMATE,
-            CONF_TARGET_SOURCE: TargetSourceType.CLIMATE,
-            CONF_TARGET_ENTITY_ID: "climate.living_room_target",
         },
     )
 
@@ -444,8 +435,6 @@ async def test_number_group_requires_number_values(hass) -> None:
             CONF_NAME: "Office",
             CONF_ENABLED: True,
             CONF_CONTROL_TYPE: ControlType.NUMBER,
-            CONF_TARGET_SOURCE: TargetSourceType.INPUT_NUMBER,
-            CONF_TARGET_ENTITY_ID: "number.office_target",
         },
     )
 
@@ -491,8 +480,8 @@ async def test_global_config_requires_flow_threshold_when_flow_sensor_is_set(has
     assert result["errors"] == {"base": "flow_threshold_required"}
 
 
-async def test_zone_rejects_target_entity_domain_mismatch(hass) -> None:
-    """Zone target entity IDs should match the selected target source type."""
+async def test_zone_uses_frost_minimum_for_initial_target_when_higher(hass) -> None:
+    """Initial owned targets should respect the higher frost floor."""
     result = await _start_basic_flow(hass)
 
     result = await hass.config_entries.flow.async_configure(
@@ -501,14 +490,28 @@ async def test_zone_rejects_target_entity_domain_mismatch(hass) -> None:
             CONF_NAME: "Living Room",
             CONF_ENABLED: True,
             CONF_CONTROL_TYPE: ControlType.CLIMATE,
-            CONF_TARGET_SOURCE: TargetSourceType.CLIMATE,
-            CONF_TARGET_ENTITY_ID: "input_number.living_room_target",
+            CONF_FROST_PROTECTION_MIN_TEMP: 21.0,
         },
     )
 
     assert result["type"] is data_entry_flow.FlowResultType.FORM
-    assert result["step_id"] == "zone"
-    assert result["errors"] == {"base": "target_entity_domain_mismatch"}
+    assert result["step_id"] == "climate_zone"
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {
+            CONF_SENSOR_ENTITY_IDS: ["sensor.living_room_temperature"],
+            CONF_CLIMATE_ENTITY_IDS: ["climate.living_room_radiator"],
+            CONF_AGGREGATION_MODE: AggregationMode.AVERAGE,
+        },
+    )
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {"add_another_zone": False},
+    )
+
+    assert result["type"] is data_entry_flow.FlowResultType.CREATE_ENTRY
+    assert result["data"][CONF_ZONES][0][CONF_TARGET_TEMPERATURE] == 21.0
 
 
 async def test_zone_requires_non_empty_name(hass) -> None:
@@ -521,8 +524,6 @@ async def test_zone_requires_non_empty_name(hass) -> None:
             CONF_NAME: "   ",
             CONF_ENABLED: True,
             CONF_CONTROL_TYPE: ControlType.CLIMATE,
-            CONF_TARGET_SOURCE: TargetSourceType.CLIMATE,
-            CONF_TARGET_ENTITY_ID: "climate.living_room_target",
         },
     )
 
@@ -541,8 +542,6 @@ async def test_local_group_requires_non_empty_name(hass) -> None:
             CONF_NAME: "Bedroom",
             CONF_ENABLED: True,
             CONF_CONTROL_TYPE: ControlType.SWITCH,
-            CONF_TARGET_SOURCE: TargetSourceType.INPUT_NUMBER,
-            CONF_TARGET_ENTITY_ID: "input_number.bedroom_target",
         },
     )
 
@@ -586,8 +585,6 @@ async def test_climate_zone_requires_primary_sensor_when_primary_mode_selected(h
             CONF_NAME: "Living Room",
             CONF_ENABLED: True,
             CONF_CONTROL_TYPE: ControlType.CLIMATE,
-            CONF_TARGET_SOURCE: TargetSourceType.CLIMATE,
-            CONF_TARGET_ENTITY_ID: "climate.living_room_target",
         },
     )
 
@@ -658,8 +655,6 @@ async def test_options_flow_updates_globals_zone_and_local_group(hass) -> None:
             CONF_NAME: "Main Bedroom",
             CONF_ENABLED: True,
             CONF_CONTROL_TYPE: ControlType.SWITCH,
-            CONF_TARGET_SOURCE: TargetSourceType.INPUT_NUMBER,
-            CONF_TARGET_ENTITY_ID: "input_number.main_bedroom_target",
             CONF_FROST_PROTECTION_MIN_TEMP: 8.0,
         },
     )
@@ -706,7 +701,7 @@ async def test_options_flow_updates_globals_zone_and_local_group(hass) -> None:
     assert result["data"][CONF_FLOW_DETECTION_THRESHOLD] == 1.5
     assert result["data"][CONF_DEFAULT_HYSTERESIS] == 0.45
     assert result["data"][CONF_ZONES][0][CONF_NAME] == "Main Bedroom"
-    assert result["data"][CONF_ZONES][0][CONF_TARGET_ENTITY_ID] == "input_number.main_bedroom_target"
+    assert result["data"][CONF_ZONES][0][CONF_TARGET_TEMPERATURE] == DEFAULT_ZONE_TARGET_TEMPERATURE
     assert result["data"][CONF_ZONES][0][CONF_FROST_PROTECTION_MIN_TEMP] == 8.0
     assert result["data"][CONF_ZONES][0][CONF_LOCAL_GROUPS][0][CONF_NAME] == "Main Radiator"
     assert (
@@ -789,8 +784,6 @@ async def test_options_flow_can_add_and_remove_zones_and_local_groups(hass) -> N
             CONF_NAME: "Bedroom",
             CONF_ENABLED: True,
             CONF_CONTROL_TYPE: ControlType.SWITCH,
-            CONF_TARGET_SOURCE: TargetSourceType.INPUT_NUMBER,
-            CONF_TARGET_ENTITY_ID: "input_number.bedroom_target",
         },
     )
     assert result["step_id"] == "manage_local_groups"
@@ -842,8 +835,6 @@ async def test_options_flow_can_add_and_remove_zones_and_local_groups(hass) -> N
             CONF_NAME: "Living Room",
             CONF_ENABLED: True,
             CONF_CONTROL_TYPE: ControlType.CLIMATE,
-            CONF_TARGET_SOURCE: TargetSourceType.CLIMATE,
-            CONF_TARGET_ENTITY_ID: "climate.living_room_target",
             CONF_FROST_PROTECTION_MIN_TEMP: 8.0,
         },
     )
@@ -884,8 +875,7 @@ async def test_options_flow_can_add_and_remove_zones_and_local_groups(hass) -> N
             CONF_NAME: "Living Room",
             CONF_ENABLED: True,
             CONF_CONTROL_TYPE: ControlType.CLIMATE,
-            CONF_TARGET_SOURCE: TargetSourceType.CLIMATE,
-            CONF_TARGET_ENTITY_ID: "climate.living_room_target",
+            CONF_TARGET_TEMPERATURE: 20.0,
             CONF_FROST_PROTECTION_MIN_TEMP: 8.0,
             CONF_SENSOR_ENTITY_IDS: ["sensor.living_room_temperature"],
             CONF_CLIMATE_ENTITY_IDS: ["climate.living_room_radiator"],
@@ -922,8 +912,6 @@ async def test_options_flow_requires_local_group_before_finishing_non_climate_zo
             CONF_NAME: "Bedroom",
             CONF_ENABLED: True,
             CONF_CONTROL_TYPE: ControlType.SWITCH,
-            CONF_TARGET_SOURCE: TargetSourceType.INPUT_NUMBER,
-            CONF_TARGET_ENTITY_ID: "input_number.bedroom_target",
         },
     )
     assert result["step_id"] == "manage_local_groups"

--- a/tests/components/multi_zone_heating/test_control_logic.py
+++ b/tests/components/multi_zone_heating/test_control_logic.py
@@ -18,7 +18,6 @@ from custom_components.multi_zone_heating.control_logic import (
 from custom_components.multi_zone_heating.models import (
     AggregationMode,
     ControlType,
-    GlobalOverride,
     LocalControlGroup,
     RelayRuntimeState,
     ZoneConfig,
@@ -77,18 +76,16 @@ def test_hysteresis_retains_previous_state_inside_band() -> None:
     assert evaluate_hysteresis_demand(20.0, 20.0, previous_demand=True, hysteresis=0.3) is False
 
 
-def test_effective_target_uses_override_and_frost_clamp() -> None:
-    """Global overrides should win and frost protection should clamp upward."""
+def test_effective_target_uses_frost_clamp() -> None:
+    """Frost protection should clamp the owned target upward."""
     assert resolve_effective_target_temperature(
         19.0,
-        global_override=GlobalOverride(target_temperature=17.0),
         zone_frost_protection_min_temp=18.0,
         global_frost_protection_min_temp=7.0,
-    ) == 18.0
+    ) == 19.0
 
     assert resolve_effective_target_temperature(
         19.0,
-        global_override=None,
         zone_frost_protection_min_temp=None,
         global_frost_protection_min_temp=20.0,
     ) == 20.0
@@ -136,7 +133,7 @@ def test_switch_zone_demand_is_aggregated_from_local_groups() -> None:
 
 
 def test_local_control_group_evaluation_is_independently_testable() -> None:
-    """A local group should apply override, frost, and hysteresis on its own."""
+    """A local group should apply frost and hysteresis on its own."""
     group = LocalControlGroup(
         name="Radiator",
         control_type=ControlType.SWITCH,
@@ -152,14 +149,13 @@ def test_local_control_group_evaluation_is_independently_testable() -> None:
         available_actuator_entity_ids=["switch.radiator"],
         previous_demand=False,
         hysteresis=0.3,
-        global_override=GlobalOverride(target_temperature=17.0),
         zone_frost_protection_min_temp=18.0,
         global_frost_protection_min_temp=7.0,
     )
 
     assert evaluation.current_temperature == 17.6
     assert evaluation.target_temperature == 19.0
-    assert evaluation.effective_target_temperature == 18.0
+    assert evaluation.effective_target_temperature == 19.0
     assert evaluation.demand is True
     assert evaluation.available_actuator_entity_ids == ["switch.radiator"]
 

--- a/tests/components/multi_zone_heating/test_control_logic.py
+++ b/tests/components/multi_zone_heating/test_control_logic.py
@@ -21,7 +21,6 @@ from custom_components.multi_zone_heating.models import (
     GlobalOverride,
     LocalControlGroup,
     RelayRuntimeState,
-    TargetSourceType,
     ZoneConfig,
 )
 
@@ -100,8 +99,7 @@ def test_switch_zone_demand_is_aggregated_from_local_groups() -> None:
     zone = ZoneConfig(
         name="Bedroom",
         control_type=ControlType.SWITCH,
-        target_source=TargetSourceType.INPUT_NUMBER,
-        target_entity_id="input_number.bedroom_target",
+        target_temperature=20.0,
         local_groups=[
             LocalControlGroup(
                 name="Radiator",
@@ -171,8 +169,7 @@ def test_climate_zone_without_any_valid_sensors_turns_demand_off() -> None:
     zone = ZoneConfig(
         name="Living Room",
         control_type=ControlType.CLIMATE,
-        target_source=TargetSourceType.CLIMATE,
-        target_entity_id="climate.living_room",
+        target_temperature=20.0,
         sensor_entity_ids=["sensor.a", "sensor.b"],
         aggregation_mode=AggregationMode.AVERAGE,
     )
@@ -198,8 +195,7 @@ def test_zone_demand_turns_off_when_no_actuators_are_available() -> None:
     zone = ZoneConfig(
         name="Bedroom",
         control_type=ControlType.SWITCH,
-        target_source=TargetSourceType.INPUT_NUMBER,
-        target_entity_id="input_number.bedroom_target",
+        target_temperature=20.0,
         local_groups=[
             LocalControlGroup(
                 name="Radiator",
@@ -231,8 +227,7 @@ def test_disabled_zone_stays_off() -> None:
     zone = ZoneConfig(
         name="Study",
         control_type=ControlType.CLIMATE,
-        target_source=TargetSourceType.CLIMATE,
-        target_entity_id="climate.study",
+        target_temperature=20.0,
         sensor_entity_ids=["sensor.study"],
         aggregation_mode=AggregationMode.AVERAGE,
         enabled=False,

--- a/tests/components/multi_zone_heating/test_coordinator.py
+++ b/tests/components/multi_zone_heating/test_coordinator.py
@@ -527,6 +527,79 @@ async def test_coordinator_turns_climate_zone_off_when_global_force_off_is_enabl
     await coordinator.async_stop()
 
 
+async def test_coordinator_restores_climate_zone_heat_when_global_force_off_is_cleared(
+    hass,
+) -> None:
+    """Clearing global force-off should return enabled climate slaves to heat mode."""
+    hass.states.async_set("sensor.living_room_temperature", "19.0")
+    hass.states.async_set(
+        "climate.radiator_a",
+        "off",
+        {"temperature": 18.0, "hvac_modes": [HVACMode.HEAT, HVACMode.OFF]},
+    )
+    hass.states.async_set("switch.boiler", "off")
+    _register_recording_switch_services(hass)
+    climate_calls, hvac_mode_calls = _register_recording_climate_services(hass)
+
+    coordinator = MultiZoneHeatingCoordinator(hass, _build_climate_config())
+    await coordinator.async_start()
+    await hass.async_block_till_done()
+
+    climate_calls.clear()
+    hvac_mode_calls.clear()
+
+    await coordinator.async_set_global_force_off(True)
+    await hass.async_block_till_done()
+
+    assert climate_calls == []
+    assert hvac_mode_calls == [{"entity_id": "climate.radiator_a", ATTR_HVAC_MODE: HVACMode.OFF}]
+
+    climate_calls.clear()
+    hvac_mode_calls.clear()
+    hass.states.async_set(
+        "climate.radiator_a",
+        "off",
+        {"temperature": 18.0, "hvac_modes": [HVACMode.HEAT, HVACMode.OFF]},
+    )
+
+    await coordinator.async_set_global_force_off(False)
+    await hass.async_block_till_done()
+
+    assert hvac_mode_calls == [{"entity_id": "climate.radiator_a", ATTR_HVAC_MODE: HVACMode.HEAT}]
+    assert climate_calls == [{"entity_id": "climate.radiator_a", "temperature": 20.0}]
+    await coordinator.async_stop()
+
+
+async def test_coordinator_restores_climate_zone_heat_when_zone_is_reenabled(hass) -> None:
+    """Re-enabling a climate zone should return supported slaves to heat mode."""
+    hass.states.async_set("sensor.living_room_temperature", "19.0")
+    hass.states.async_set(
+        "climate.radiator_a",
+        "off",
+        {"temperature": 18.0, "hvac_modes": [HVACMode.HEAT, HVACMode.OFF]},
+    )
+    hass.states.async_set("switch.boiler", "off")
+    _register_recording_switch_services(hass)
+    climate_calls, hvac_mode_calls = _register_recording_climate_services(hass)
+
+    coordinator = MultiZoneHeatingCoordinator(
+        hass,
+        _build_climate_config(enabled=False),
+    )
+    await coordinator.async_start()
+    await hass.async_block_till_done()
+
+    assert climate_calls == []
+    assert hvac_mode_calls == []
+
+    await coordinator.async_set_zone_enabled("Living Room", True)
+    await hass.async_block_till_done()
+
+    assert hvac_mode_calls == [{"entity_id": "climate.radiator_a", ATTR_HVAC_MODE: HVACMode.HEAT}]
+    assert climate_calls == [{"entity_id": "climate.radiator_a", "temperature": 20.0}]
+    await coordinator.async_stop()
+
+
 async def test_coordinator_uses_climate_fallback_target_when_disabled_and_off_is_unsupported(
     hass,
 ) -> None:

--- a/tests/components/multi_zone_heating/test_coordinator.py
+++ b/tests/components/multi_zone_heating/test_coordinator.py
@@ -91,9 +91,18 @@ def _register_recording_climate_services(hass) -> tuple[list[dict[str, object]],
 
     async def _record_set_temperature(call: ServiceCall) -> None:
         temperature_calls.append(dict(call.data))
+        entity_id = call.data["entity_id"]
+        state = hass.states.get(entity_id)
+        attributes = dict(state.attributes) if state is not None else {}
+        attributes["temperature"] = call.data["temperature"]
+        hass.states.async_set(entity_id, state.state if state is not None else HVACMode.HEAT, attributes)
 
     async def _record_set_hvac_mode(call: ServiceCall) -> None:
         hvac_mode_calls.append(dict(call.data))
+        entity_id = call.data["entity_id"]
+        state = hass.states.get(entity_id)
+        attributes = dict(state.attributes) if state is not None else {}
+        hass.states.async_set(entity_id, call.data[ATTR_HVAC_MODE], attributes)
 
     hass.services.async_register("climate", SERVICE_SET_TEMPERATURE, _record_set_temperature)
     hass.services.async_register("climate", SERVICE_SET_HVAC_MODE, _record_set_hvac_mode)
@@ -106,6 +115,7 @@ def _register_recording_number_services(hass) -> list[dict[str, object]]:
 
     async def _record_set_value(call: ServiceCall) -> None:
         calls.append(dict(call.data))
+        hass.states.async_set(call.data["entity_id"], str(call.data[ATTR_VALUE]))
 
     hass.services.async_register("number", SERVICE_SET_VALUE, _record_set_value)
     return calls
@@ -297,6 +307,56 @@ async def test_coordinator_dispatches_climate_targets(hass) -> None:
     await coordinator.async_stop()
 
 
+async def test_coordinator_keeps_owned_target_when_slave_climate_target_changes(hass) -> None:
+    """Slave climate targets should not replace the zone-owned target."""
+    hass.states.async_set("sensor.living_room_temperature", "19.0")
+    hass.states.async_set(
+        "climate.radiator_a",
+        "heat",
+        {"temperature": 18.0, "hvac_modes": [HVACMode.HEAT, HVACMode.OFF]},
+    )
+    hass.states.async_set("switch.boiler", "off")
+    _register_recording_switch_services(hass)
+    climate_calls, _ = _register_recording_climate_services(hass)
+
+    coordinator = MultiZoneHeatingCoordinator(
+        hass,
+        IntegrationConfig(
+            main_relay_entity_id="switch.boiler",
+            zones=[
+                ZoneConfig(
+                    name="Living Room",
+                    control_type=ControlType.CLIMATE,
+                    target_temperature=21.0,
+                    sensor_entity_ids=["sensor.living_room_temperature"],
+                    climate_entity_ids=["climate.radiator_a"],
+                    aggregation_mode=AggregationMode.AVERAGE,
+                )
+            ],
+        ),
+    )
+
+    await coordinator.async_start()
+    await hass.async_block_till_done()
+
+    assert climate_calls == [{"entity_id": "climate.radiator_a", "temperature": 21.0}]
+
+    climate_calls.clear()
+    hass.states.async_set(
+        "climate.radiator_a",
+        "heat",
+        {"temperature": 24.0, "hvac_modes": [HVACMode.HEAT, HVACMode.OFF]},
+    )
+
+    await coordinator.async_request_refresh()
+    await hass.async_block_till_done()
+
+    assert coordinator.data is not None
+    assert coordinator.data.target_temperatures["Living Room"] == 21.0
+    assert coordinator.data.zone_evaluations[0].target_temperature == 21.0
+    await coordinator.async_stop()
+
+
 async def test_coordinator_restores_heat_mode_before_setting_target(hass) -> None:
     """Climate zones should resume heat mode before pushing the target again."""
     hass.states.async_set("sensor.living_room_temperature", "19.0")
@@ -447,6 +507,55 @@ async def test_coordinator_dispatches_number_group_values(hass) -> None:
     await hass.async_block_till_done()
 
     assert number_calls == [{"entity_id": "number.floor_valve", ATTR_VALUE: 100.0}]
+    await coordinator.async_stop()
+
+
+async def test_coordinator_number_groups_keep_using_the_owned_zone_target(hass) -> None:
+    """Number groups should reevaluate against the zone-owned target only."""
+    hass.states.async_set("sensor.floor_temperature", "19.4")
+    hass.states.async_set("number.floor_valve", "0")
+    hass.states.async_set("switch.boiler", "off")
+    _register_recording_switch_services(hass)
+    number_calls = _register_recording_number_services(hass)
+
+    zone = ZoneConfig(
+        name="Floor",
+        control_type=ControlType.NUMBER,
+        target_temperature=20.0,
+        local_groups=[
+            LocalControlGroup(
+                name="Valve",
+                control_type=ControlType.NUMBER,
+                actuator_entity_ids=["number.floor_valve"],
+                sensor_entity_ids=["sensor.floor_temperature"],
+                aggregation_mode=AggregationMode.AVERAGE,
+                number_semantic_type=NumberSemanticType.PERCENTAGE,
+                active_value=100.0,
+                inactive_value=0.0,
+            )
+        ],
+    )
+    coordinator = MultiZoneHeatingCoordinator(
+        hass,
+        IntegrationConfig(
+            main_relay_entity_id="switch.boiler",
+            zones=[zone],
+        ),
+    )
+
+    await coordinator.async_start()
+    await hass.async_block_till_done()
+
+    assert number_calls == [{"entity_id": "number.floor_valve", ATTR_VALUE: 100.0}]
+    assert coordinator.data is not None
+    assert coordinator.data.zone_evaluations[0].local_groups[0].target_temperature == 20.0
+
+    number_calls.clear()
+    await coordinator.async_set_zone_target_temperature("Floor", 19.0)
+
+    assert coordinator.data is not None
+    assert coordinator.data.zone_evaluations[0].local_groups[0].target_temperature == 19.0
+    assert number_calls == [{"entity_id": "number.floor_valve", ATTR_VALUE: 0.0}]
     await coordinator.async_stop()
 
 

--- a/tests/components/multi_zone_heating/test_coordinator.py
+++ b/tests/components/multi_zone_heating/test_coordinator.py
@@ -559,6 +559,60 @@ async def test_coordinator_number_groups_keep_using_the_owned_zone_target(hass) 
     await coordinator.async_stop()
 
 
+async def test_coordinator_resends_number_command_after_external_drift(hass) -> None:
+    """External actuator drift should clear stale pending number commands."""
+    hass.states.async_set("sensor.floor_temperature", "19.0")
+    hass.states.async_set("number.floor_valve", "0")
+    hass.states.async_set("switch.boiler", "off")
+    _register_recording_switch_services(hass)
+    number_calls: list[dict[str, object]] = []
+
+    async def _record_set_value(call: ServiceCall) -> None:
+        number_calls.append(dict(call.data))
+
+    hass.services.async_register("number", SERVICE_SET_VALUE, _record_set_value)
+
+    coordinator = MultiZoneHeatingCoordinator(
+        hass,
+        IntegrationConfig(
+            main_relay_entity_id="switch.boiler",
+            zones=[
+                ZoneConfig(
+                    name="Floor",
+                    control_type=ControlType.NUMBER,
+                    target_temperature=20.0,
+                    local_groups=[
+                        LocalControlGroup(
+                            name="Valve",
+                            control_type=ControlType.NUMBER,
+                            actuator_entity_ids=["number.floor_valve"],
+                            sensor_entity_ids=["sensor.floor_temperature"],
+                            aggregation_mode=AggregationMode.AVERAGE,
+                            number_semantic_type=NumberSemanticType.PERCENTAGE,
+                            active_value=100.0,
+                            inactive_value=0.0,
+                        )
+                    ],
+                )
+            ],
+        ),
+    )
+
+    await coordinator.async_start()
+    await hass.async_block_till_done()
+
+    assert number_calls == [{"entity_id": "number.floor_valve", ATTR_VALUE: 100.0}]
+
+    number_calls.clear()
+    hass.states.async_set("number.floor_valve", "50")
+
+    await coordinator.async_request_refresh()
+    await hass.async_block_till_done()
+
+    assert number_calls == [{"entity_id": "number.floor_valve", ATTR_VALUE: 100.0}]
+    await coordinator.async_stop()
+
+
 async def test_coordinator_ignores_groups_with_no_available_actuators(hass) -> None:
     """The relay should stay off when a demanding group has no available actuators left."""
     hass.states.async_set("sensor.floor_temperature", "19.0")

--- a/tests/components/multi_zone_heating/test_coordinator.py
+++ b/tests/components/multi_zone_heating/test_coordinator.py
@@ -24,7 +24,6 @@ from custom_components.multi_zone_heating.models import (
     IntegrationConfig,
     LocalControlGroup,
     NumberSemanticType,
-    TargetSourceType,
     ZoneConfig,
 )
 
@@ -39,8 +38,7 @@ def _build_switch_config(*, relay_off_delay_seconds: int = 0) -> IntegrationConf
             ZoneConfig(
                 name="Living Room",
                 control_type=ControlType.SWITCH,
-                target_source=TargetSourceType.INPUT_NUMBER,
-                target_entity_id="input_number.living_room_target",
+                target_temperature=20.0,
                 local_groups=[
                     LocalControlGroup(
                         name="Radiator",
@@ -118,7 +116,6 @@ async def test_coordinator_dispatches_switch_group_and_relay_once_until_state_ch
 ) -> None:
     """Repeated reevaluations should not spam duplicate commands."""
     hass.states.async_set("sensor.living_room_temperature", "19.0")
-    hass.states.async_set("input_number.living_room_target", "20.0")
     hass.states.async_set("switch.radiator", "off")
     hass.states.async_set("switch.boiler", "off")
 
@@ -143,7 +140,6 @@ async def test_coordinator_dispatches_switch_group_and_relay_once_until_state_ch
 
 async def test_coordinator_tracks_unavailable_entities_in_snapshot(hass) -> None:
     """Missing sensors and actuators should be exposed in the runtime snapshot."""
-    hass.states.async_set("input_number.living_room_target", "20.0")
     hass.states.async_set("switch.boiler", "off")
 
     coordinator = MultiZoneHeatingCoordinator(hass, _build_switch_config())
@@ -153,7 +149,6 @@ async def test_coordinator_tracks_unavailable_entities_in_snapshot(hass) -> None
     assert coordinator.data is not None
     assert "sensor.living_room_temperature" in coordinator.data.unavailable_entity_ids
     assert "switch.radiator" in coordinator.data.unavailable_entity_ids
-    assert "input_number.living_room_target" not in coordinator.data.unavailable_entity_ids
     assert coordinator.data.system_demand is False
     await coordinator.async_stop()
 
@@ -162,7 +157,6 @@ async def test_coordinator_rechecks_relay_after_off_delay(hass, monkeypatch) -> 
     """A deferred relay-off should complete via the scheduled reevaluation."""
     now = datetime(2026, 4, 8, 10, 0, tzinfo=UTC)
     hass.states.async_set("sensor.living_room_temperature", "20.5")
-    hass.states.async_set("input_number.living_room_target", "20.0")
     hass.states.async_set("switch.radiator", "off")
     hass.states.async_set("switch.boiler", "on")
 
@@ -198,7 +192,6 @@ async def test_coordinator_rechecks_relay_after_off_delay(hass, monkeypatch) -> 
 async def test_coordinator_dispatches_input_boolean_global_relay(hass) -> None:
     """The main relay may be backed by an input_boolean helper."""
     hass.states.async_set("sensor.living_room_temperature", "19.0")
-    hass.states.async_set("input_number.living_room_target", "20.0")
     hass.states.async_set("switch.radiator", "off")
     hass.states.async_set("input_boolean.boiler_enable", "off")
 
@@ -233,7 +226,6 @@ async def test_coordinator_raises_missing_flow_warning_after_timeout(hass, monke
     """Missing-flow warnings should trip on the scheduled timeout boundary."""
     now = datetime(2026, 4, 8, 10, 0, tzinfo=UTC)
     hass.states.async_set("sensor.living_room_temperature", "19.0")
-    hass.states.async_set("input_number.living_room_target", "20.0")
     hass.states.async_set("sensor.system_flow", "0.0")
     hass.states.async_set("switch.radiator", "off")
     hass.states.async_set("switch.boiler", "on")
@@ -274,7 +266,6 @@ async def test_coordinator_raises_missing_flow_warning_after_timeout(hass, monke
 async def test_coordinator_dispatches_climate_targets(hass) -> None:
     """Climate zones should set shared target temperatures once."""
     hass.states.async_set("sensor.living_room_temperature", "19.0")
-    hass.states.async_set("climate.zone_target", "heat", {"temperature": 21.0})
     hass.states.async_set("climate.radiator_a", "heat", {"temperature": 18.0})
     hass.states.async_set("climate.radiator_b", "heat", {"temperature": 21.0})
     hass.states.async_set("switch.boiler", "off")
@@ -289,8 +280,7 @@ async def test_coordinator_dispatches_climate_targets(hass) -> None:
                 ZoneConfig(
                     name="Living Room",
                     control_type=ControlType.CLIMATE,
-                    target_source=TargetSourceType.CLIMATE,
-                    target_entity_id="climate.zone_target",
+                    target_temperature=21.0,
                     sensor_entity_ids=["sensor.living_room_temperature"],
                     climate_entity_ids=["climate.radiator_a", "climate.radiator_b"],
                     aggregation_mode=AggregationMode.AVERAGE,
@@ -310,7 +300,6 @@ async def test_coordinator_dispatches_climate_targets(hass) -> None:
 async def test_coordinator_restores_heat_mode_before_setting_target(hass) -> None:
     """Climate zones should resume heat mode before pushing the target again."""
     hass.states.async_set("sensor.living_room_temperature", "19.0")
-    hass.states.async_set("climate.zone_target", "heat", {"temperature": 21.0})
     hass.states.async_set(
         "climate.radiator_a",
         "off",
@@ -328,8 +317,7 @@ async def test_coordinator_restores_heat_mode_before_setting_target(hass) -> Non
                 ZoneConfig(
                     name="Living Room",
                     control_type=ControlType.CLIMATE,
-                    target_source=TargetSourceType.CLIMATE,
-                    target_entity_id="climate.zone_target",
+                    target_temperature=21.0,
                     sensor_entity_ids=["sensor.living_room_temperature"],
                     climate_entity_ids=["climate.radiator_a"],
                     aggregation_mode=AggregationMode.AVERAGE,
@@ -349,7 +337,6 @@ async def test_coordinator_restores_heat_mode_before_setting_target(hass) -> Non
 async def test_coordinator_turns_climate_zone_off_when_demand_clears(hass) -> None:
     """Climate zones should turn supported actuators off when they stop demanding heat."""
     hass.states.async_set("sensor.living_room_temperature", "20.5")
-    hass.states.async_set("climate.zone_target", "heat", {"temperature": 20.0})
     hass.states.async_set(
         "climate.radiator_a",
         "heat",
@@ -367,8 +354,7 @@ async def test_coordinator_turns_climate_zone_off_when_demand_clears(hass) -> No
                 ZoneConfig(
                     name="Living Room",
                     control_type=ControlType.CLIMATE,
-                    target_source=TargetSourceType.CLIMATE,
-                    target_entity_id="climate.zone_target",
+                    target_temperature=20.0,
                     sensor_entity_ids=["sensor.living_room_temperature"],
                     climate_entity_ids=["climate.radiator_a"],
                     aggregation_mode=AggregationMode.AVERAGE,
@@ -388,7 +374,6 @@ async def test_coordinator_turns_climate_zone_off_when_demand_clears(hass) -> No
 async def test_coordinator_uses_climate_fallback_target_when_off_is_unsupported(hass) -> None:
     """Climate zones should write the fallback target when off cannot be selected."""
     hass.states.async_set("sensor.living_room_temperature", "20.5")
-    hass.states.async_set("climate.zone_target", "heat", {"temperature": 20.0})
     hass.states.async_set(
         "climate.radiator_a",
         "heat",
@@ -406,8 +391,7 @@ async def test_coordinator_uses_climate_fallback_target_when_off_is_unsupported(
                 ZoneConfig(
                     name="Living Room",
                     control_type=ControlType.CLIMATE,
-                    target_source=TargetSourceType.CLIMATE,
-                    target_entity_id="climate.zone_target",
+                    target_temperature=20.0,
                     sensor_entity_ids=["sensor.living_room_temperature"],
                     climate_entity_ids=["climate.radiator_a"],
                     climate_off_fallback_temperature=7.5,
@@ -428,7 +412,6 @@ async def test_coordinator_uses_climate_fallback_target_when_off_is_unsupported(
 async def test_coordinator_dispatches_number_group_values(hass) -> None:
     """Number groups should write the configured active value."""
     hass.states.async_set("sensor.floor_temperature", "19.0")
-    hass.states.async_set("input_number.floor_target", "20.0")
     hass.states.async_set("number.floor_valve", "0")
     hass.states.async_set("switch.boiler", "off")
     _register_recording_switch_services(hass)
@@ -442,8 +425,7 @@ async def test_coordinator_dispatches_number_group_values(hass) -> None:
                 ZoneConfig(
                     name="Floor",
                     control_type=ControlType.NUMBER,
-                    target_source=TargetSourceType.INPUT_NUMBER,
-                    target_entity_id="input_number.floor_target",
+                    target_temperature=20.0,
                     local_groups=[
                         LocalControlGroup(
                             name="Valve",
@@ -471,7 +453,6 @@ async def test_coordinator_dispatches_number_group_values(hass) -> None:
 async def test_coordinator_ignores_groups_with_no_available_actuators(hass) -> None:
     """The relay should stay off when a demanding group has no available actuators left."""
     hass.states.async_set("sensor.floor_temperature", "19.0")
-    hass.states.async_set("input_number.floor_target", "20.0")
     hass.states.async_set("switch.boiler", "off")
     calls = _register_recording_switch_services(hass)
 
@@ -483,8 +464,7 @@ async def test_coordinator_ignores_groups_with_no_available_actuators(hass) -> N
                 ZoneConfig(
                     name="Floor",
                     control_type=ControlType.SWITCH,
-                    target_source=TargetSourceType.INPUT_NUMBER,
-                    target_entity_id="input_number.floor_target",
+                    target_temperature=20.0,
                     local_groups=[
                         LocalControlGroup(
                             name="Valve",
@@ -526,8 +506,7 @@ def test_integration_config_from_dict_builds_typed_models() -> None:
                     "name": "Living Room",
                     "enabled": True,
                     "control_type": ControlType.NUMBER,
-                    "target_source": TargetSourceType.INPUT_NUMBER,
-                    "target_entity_id": "input_number.living_room_target",
+                    "target_temperature": 20.0,
                     "sensor_entity_ids": [],
                     "climate_entity_ids": [],
                     "climate_off_fallback_temperature": None,
@@ -557,7 +536,7 @@ def test_integration_config_from_dict_builds_typed_models() -> None:
     assert config.missing_flow_timeout_seconds == 90
     assert config.default_hysteresis == 0.4
     assert config.zones[0].control_type is ControlType.NUMBER
-    assert config.zones[0].target_source is TargetSourceType.INPUT_NUMBER
+    assert config.zones[0].target_temperature == 20.0
     assert config.zones[0].climate_off_fallback_temperature is None
     assert config.zones[0].local_groups[0].aggregation_mode is AggregationMode.MINIMUM
     assert config.zones[0].local_groups[0].number_semantic_type is NumberSemanticType.PERCENTAGE

--- a/tests/components/multi_zone_heating/test_coordinator.py
+++ b/tests/components/multi_zone_heating/test_coordinator.py
@@ -62,6 +62,30 @@ def _build_flow_warning_config(*, missing_flow_timeout_seconds: int) -> Integrat
     return config
 
 
+def _build_climate_config(
+    *,
+    target_temperature: float = 20.0,
+    enabled: bool = True,
+    climate_off_fallback_temperature: float | None = None,
+) -> IntegrationConfig:
+    """Create a small config with one climate-controlled zone."""
+    return IntegrationConfig(
+        main_relay_entity_id="switch.boiler",
+        zones=[
+            ZoneConfig(
+                name="Living Room",
+                control_type=ControlType.CLIMATE,
+                target_temperature=target_temperature,
+                sensor_entity_ids=["sensor.living_room_temperature"],
+                climate_entity_ids=["climate.radiator_a"],
+                climate_off_fallback_temperature=climate_off_fallback_temperature,
+                aggregation_mode=AggregationMode.AVERAGE,
+                enabled=enabled,
+            )
+        ],
+    )
+
+
 def _register_recording_switch_services(hass) -> list[tuple[str, dict[str, str]]]:
     """Register fake switch services and record each invocation."""
     return _register_recording_toggle_services(hass, "switch")
@@ -371,19 +395,7 @@ async def test_coordinator_restores_heat_mode_before_setting_target(hass) -> Non
 
     coordinator = MultiZoneHeatingCoordinator(
         hass,
-        IntegrationConfig(
-            main_relay_entity_id="switch.boiler",
-            zones=[
-                ZoneConfig(
-                    name="Living Room",
-                    control_type=ControlType.CLIMATE,
-                    target_temperature=21.0,
-                    sensor_entity_ids=["sensor.living_room_temperature"],
-                    climate_entity_ids=["climate.radiator_a"],
-                    aggregation_mode=AggregationMode.AVERAGE,
-                )
-            ],
-        ),
+        _build_climate_config(target_temperature=21.0),
     )
 
     await coordinator.async_start()
@@ -394,8 +406,77 @@ async def test_coordinator_restores_heat_mode_before_setting_target(hass) -> Non
     await coordinator.async_stop()
 
 
-async def test_coordinator_turns_climate_zone_off_when_demand_clears(hass) -> None:
-    """Climate zones should turn supported actuators off when they stop demanding heat."""
+async def test_coordinator_keeps_climate_zone_in_heat_when_demand_clears(hass) -> None:
+    """Climate zones should not turn supported actuators off just because demand cleared."""
+    hass.states.async_set("sensor.living_room_temperature", "20.5")
+    hass.states.async_set(
+        "climate.radiator_a",
+        "heat",
+        {"temperature": 20.0, "hvac_modes": [HVACMode.HEAT, HVACMode.OFF]},
+    )
+    hass.states.async_set("switch.boiler", "on")
+    _register_recording_switch_services(hass)
+    climate_calls, hvac_mode_calls = _register_recording_climate_services(hass)
+
+    coordinator = MultiZoneHeatingCoordinator(hass, _build_climate_config())
+
+    await coordinator.async_start()
+    await hass.async_block_till_done()
+
+    assert climate_calls == []
+    assert hvac_mode_calls == []
+    await coordinator.async_stop()
+
+
+async def test_coordinator_keeps_syncing_target_when_demand_clears(hass) -> None:
+    """Climate zones should keep syncing the owned target even while demand is false."""
+    hass.states.async_set("sensor.living_room_temperature", "20.5")
+    hass.states.async_set(
+        "climate.radiator_a",
+        "heat",
+        {"temperature": 18.0, "hvac_modes": [HVACMode.HEAT, HVACMode.OFF]},
+    )
+    hass.states.async_set("switch.boiler", "on")
+    _register_recording_switch_services(hass)
+    climate_calls, hvac_mode_calls = _register_recording_climate_services(hass)
+
+    coordinator = MultiZoneHeatingCoordinator(hass, _build_climate_config(target_temperature=20.0))
+
+    await coordinator.async_start()
+    await hass.async_block_till_done()
+
+    assert climate_calls == [{"entity_id": "climate.radiator_a", "temperature": 20.0}]
+    assert hvac_mode_calls == []
+    await coordinator.async_stop()
+
+
+async def test_coordinator_restores_non_heat_mode_to_heat_when_zone_master_is_active(hass) -> None:
+    """Climate zones should correct slave modes like auto back to heat while enabled."""
+    hass.states.async_set("sensor.living_room_temperature", "19.0")
+    hass.states.async_set(
+        "climate.radiator_a",
+        HVACMode.AUTO,
+        {"temperature": 18.0, "hvac_modes": [HVACMode.AUTO, HVACMode.HEAT, HVACMode.OFF]},
+    )
+    hass.states.async_set("switch.boiler", "off")
+    _register_recording_switch_services(hass)
+    climate_calls, hvac_mode_calls = _register_recording_climate_services(hass)
+
+    coordinator = MultiZoneHeatingCoordinator(
+        hass,
+        _build_climate_config(target_temperature=21.0),
+    )
+
+    await coordinator.async_start()
+    await hass.async_block_till_done()
+
+    assert hvac_mode_calls == [{"entity_id": "climate.radiator_a", ATTR_HVAC_MODE: HVACMode.HEAT}]
+    assert climate_calls == [{"entity_id": "climate.radiator_a", "temperature": 21.0}]
+    await coordinator.async_stop()
+
+
+async def test_coordinator_turns_climate_zone_off_when_disabled(hass) -> None:
+    """Climate zones should turn supported actuators off when the zone is disabled."""
     hass.states.async_set("sensor.living_room_temperature", "20.5")
     hass.states.async_set(
         "climate.radiator_a",
@@ -408,19 +489,7 @@ async def test_coordinator_turns_climate_zone_off_when_demand_clears(hass) -> No
 
     coordinator = MultiZoneHeatingCoordinator(
         hass,
-        IntegrationConfig(
-            main_relay_entity_id="switch.boiler",
-            zones=[
-                ZoneConfig(
-                    name="Living Room",
-                    control_type=ControlType.CLIMATE,
-                    target_temperature=20.0,
-                    sensor_entity_ids=["sensor.living_room_temperature"],
-                    climate_entity_ids=["climate.radiator_a"],
-                    aggregation_mode=AggregationMode.AVERAGE,
-                )
-            ],
-        ),
+        _build_climate_config(enabled=False),
     )
 
     await coordinator.async_start()
@@ -431,8 +500,37 @@ async def test_coordinator_turns_climate_zone_off_when_demand_clears(hass) -> No
     await coordinator.async_stop()
 
 
-async def test_coordinator_uses_climate_fallback_target_when_off_is_unsupported(hass) -> None:
-    """Climate zones should write the fallback target when off cannot be selected."""
+async def test_coordinator_turns_climate_zone_off_when_global_force_off_is_enabled(hass) -> None:
+    """Climate zones should turn supported actuators off during global force-off."""
+    hass.states.async_set("sensor.living_room_temperature", "20.5")
+    hass.states.async_set(
+        "climate.radiator_a",
+        "heat",
+        {"temperature": 20.0, "hvac_modes": [HVACMode.HEAT, HVACMode.OFF]},
+    )
+    hass.states.async_set("switch.boiler", "on")
+    _register_recording_switch_services(hass)
+    climate_calls, hvac_mode_calls = _register_recording_climate_services(hass)
+
+    coordinator = MultiZoneHeatingCoordinator(hass, _build_climate_config())
+    await coordinator.async_start()
+    await hass.async_block_till_done()
+
+    climate_calls.clear()
+    hvac_mode_calls.clear()
+
+    await coordinator.async_set_global_force_off(True)
+    await hass.async_block_till_done()
+
+    assert climate_calls == []
+    assert hvac_mode_calls == [{"entity_id": "climate.radiator_a", ATTR_HVAC_MODE: HVACMode.OFF}]
+    await coordinator.async_stop()
+
+
+async def test_coordinator_uses_climate_fallback_target_when_disabled_and_off_is_unsupported(
+    hass,
+) -> None:
+    """Climate zones should write the fallback target when disabled and off cannot be selected."""
     hass.states.async_set("sensor.living_room_temperature", "20.5")
     hass.states.async_set(
         "climate.radiator_a",
@@ -445,23 +543,45 @@ async def test_coordinator_uses_climate_fallback_target_when_off_is_unsupported(
 
     coordinator = MultiZoneHeatingCoordinator(
         hass,
-        IntegrationConfig(
-            main_relay_entity_id="switch.boiler",
-            zones=[
-                ZoneConfig(
-                    name="Living Room",
-                    control_type=ControlType.CLIMATE,
-                    target_temperature=20.0,
-                    sensor_entity_ids=["sensor.living_room_temperature"],
-                    climate_entity_ids=["climate.radiator_a"],
-                    climate_off_fallback_temperature=7.5,
-                    aggregation_mode=AggregationMode.AVERAGE,
-                )
-            ],
+        _build_climate_config(
+            enabled=False,
+            climate_off_fallback_temperature=7.5,
         ),
     )
 
     await coordinator.async_start()
+    await hass.async_block_till_done()
+
+    assert climate_calls == [{"entity_id": "climate.radiator_a", "temperature": 7.5}]
+    assert hvac_mode_calls == []
+    await coordinator.async_stop()
+
+
+async def test_coordinator_uses_climate_fallback_target_when_forced_off_and_off_is_unsupported(
+    hass,
+) -> None:
+    """Climate zones should write the fallback target during global force-off when off is unsupported."""
+    hass.states.async_set("sensor.living_room_temperature", "20.5")
+    hass.states.async_set(
+        "climate.radiator_a",
+        "heat",
+        {"temperature": 20.0, "hvac_modes": [HVACMode.HEAT]},
+    )
+    hass.states.async_set("switch.boiler", "on")
+    _register_recording_switch_services(hass)
+    climate_calls, hvac_mode_calls = _register_recording_climate_services(hass)
+
+    coordinator = MultiZoneHeatingCoordinator(
+        hass,
+        _build_climate_config(climate_off_fallback_temperature=7.5),
+    )
+    await coordinator.async_start()
+    await hass.async_block_till_done()
+
+    climate_calls.clear()
+    hvac_mode_calls.clear()
+
+    await coordinator.async_set_global_force_off(True)
     await hass.async_block_till_done()
 
     assert climate_calls == [{"entity_id": "climate.radiator_a", "temperature": 7.5}]

--- a/tests/components/multi_zone_heating/test_diagnostics.py
+++ b/tests/components/multi_zone_heating/test_diagnostics.py
@@ -80,6 +80,15 @@ async def test_config_entry_diagnostics_include_config_and_runtime_state(hass) -
     assert diagnostics["config"]["zones"][0]["control_type"] == "switch"
     assert diagnostics["runtime"]["loaded"] is True
     assert diagnostics["runtime"]["global_force_off"] is False
+    assert diagnostics["runtime"]["system_climate"]["hvac_mode"] == "heat"
+    assert diagnostics["runtime"]["system_climate"]["target_temperature"] == 20.0
+    assert diagnostics["runtime"]["system_climate"]["zone_target_temperatures"] == {
+        "Living Room": 20.0,
+    }
+    assert diagnostics["runtime"]["zone_climates"][0]["name"] == "Living Room"
+    assert diagnostics["runtime"]["zone_climates"][0]["target_temperature"] == 20.0
+    assert diagnostics["runtime"]["zone_climates"][0]["effective_target_temperature"] == 20.0
+    assert diagnostics["runtime"]["zone_climates"][0]["local_groups"][0]["target_temperature"] == 20.0
     assert diagnostics["runtime"]["snapshot"]["flow_detected"] is False
     assert diagnostics["runtime"]["snapshot"]["relay_runtime_state"]["is_on"] is True
     assert diagnostics["runtime"]["snapshot"]["zone_evaluations"][0]["name"] == "Living Room"

--- a/tests/components/multi_zone_heating/test_diagnostics.py
+++ b/tests/components/multi_zone_heating/test_diagnostics.py
@@ -29,8 +29,7 @@ def _build_config_entry() -> MockConfigEntry:
                     "name": "Living Room",
                     "enabled": True,
                     "control_type": "switch",
-                    "target_source": "input_number",
-                    "target_entity_id": "input_number.living_room_target",
+                    "target_temperature": 20.0,
                     "local_groups": [
                         {
                             "name": "Radiator",
@@ -63,7 +62,6 @@ def _register_recording_switch_services(hass) -> None:
 async def test_config_entry_diagnostics_include_config_and_runtime_state(hass) -> None:
     """Diagnostics should expose both typed config and live runtime state."""
     hass.states.async_set("sensor.living_room_temperature", "19.0")
-    hass.states.async_set("input_number.living_room_target", "20.0")
     hass.states.async_set("sensor.system_flow", "0.0")
     hass.states.async_set("switch.radiator", STATE_OFF)
     hass.states.async_set("switch.boiler", STATE_OFF)
@@ -77,7 +75,7 @@ async def test_config_entry_diagnostics_include_config_and_runtime_state(hass) -
 
     diagnostics = await async_get_config_entry_diagnostics(hass, entry)
 
-    assert diagnostics["config_entry"]["version"] == 1
+    assert diagnostics["config_entry"]["version"] == 2
     assert diagnostics["config"]["main_relay_entity_id"] == "switch.boiler"
     assert diagnostics["config"]["zones"][0]["control_type"] == "switch"
     assert diagnostics["runtime"]["loaded"] is True

--- a/tests/components/multi_zone_heating/test_diagnostics.py
+++ b/tests/components/multi_zone_heating/test_diagnostics.py
@@ -86,6 +86,10 @@ async def test_config_entry_diagnostics_include_config_and_runtime_state(hass) -
         "Living Room": 20.0,
     }
     assert diagnostics["runtime"]["zone_climates"][0]["name"] == "Living Room"
+    assert diagnostics["runtime"]["zone_climates"][0]["hvac_mode"] == "heat"
+    assert diagnostics["runtime"]["zone_climates"][0]["hvac_action"] == "heating"
+    assert diagnostics["runtime"]["zone_climates"][0]["demand"] is True
+    assert diagnostics["runtime"]["zone_climates"][0]["global_force_off"] is False
     assert diagnostics["runtime"]["zone_climates"][0]["target_temperature"] == 20.0
     assert diagnostics["runtime"]["zone_climates"][0]["effective_target_temperature"] == 20.0
     assert diagnostics["runtime"]["zone_climates"][0]["local_groups"][0]["target_temperature"] == 20.0
@@ -96,3 +100,44 @@ async def test_config_entry_diagnostics_include_config_and_runtime_state(hass) -
     assert diagnostics["runtime"]["snapshot"]["target_temperatures"] == {
         "Living Room": 20.0,
     }
+
+
+async def test_zone_climate_diagnostics_distinguish_idle_disabled_and_forced_off(hass) -> None:
+    """Zone diagnostics should separate demand, zone enable, and global force-off."""
+    hass.states.async_set("sensor.living_room_temperature", "20.5")
+    hass.states.async_set("sensor.system_flow", "0.0")
+    hass.states.async_set("switch.radiator", STATE_OFF)
+    hass.states.async_set("switch.boiler", STATE_OFF)
+    _register_recording_switch_services(hass)
+
+    entry = _build_config_entry()
+    entry.add_to_hass(hass)
+
+    assert await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    diagnostics = await async_get_config_entry_diagnostics(hass, entry)
+    zone = diagnostics["runtime"]["zone_climates"][0]
+    assert zone["hvac_mode"] == "heat"
+    assert zone["hvac_action"] == "idle"
+    assert zone["demand"] is False
+
+    await entry.runtime_data.coordinator.async_set_zone_enabled("Living Room", False)
+    await hass.async_block_till_done()
+
+    diagnostics = await async_get_config_entry_diagnostics(hass, entry)
+    zone = diagnostics["runtime"]["zone_climates"][0]
+    assert zone["hvac_mode"] == "off"
+    assert zone["hvac_action"] == "off"
+    assert zone["demand"] is False
+
+    await entry.runtime_data.coordinator.async_set_zone_enabled("Living Room", True)
+    await entry.runtime_data.coordinator.async_set_global_force_off(True)
+    await hass.async_block_till_done()
+
+    diagnostics = await async_get_config_entry_diagnostics(hass, entry)
+    zone = diagnostics["runtime"]["zone_climates"][0]
+    assert zone["hvac_mode"] == "heat"
+    assert zone["hvac_action"] == "off"
+    assert zone["demand"] is False
+    assert zone["global_force_off"] is True

--- a/tests/components/multi_zone_heating/test_entities.py
+++ b/tests/components/multi_zone_heating/test_entities.py
@@ -105,6 +105,97 @@ async def test_system_climate_sets_and_clears_override(hass) -> None:
     assert climate_state.attributes["override_target_temperature"] == 21.5
 
 
+async def test_zone_climate_exposes_and_persists_owned_target(hass) -> None:
+    """Each zone should expose a climate entity with an owned target."""
+    entry, _ = await _setup_loaded_entry(hass)
+
+    climate_state = hass.states.get("climate.multi_zone_heating_living_room")
+    assert climate_state is not None
+    assert climate_state.state == "heat"
+    assert climate_state.attributes["temperature"] == 20.0
+    assert climate_state.attributes["current_temperature"] is None
+
+    await hass.services.async_call(
+        "climate",
+        "set_temperature",
+        {
+            ATTR_ENTITY_ID: "climate.multi_zone_heating_living_room",
+            "temperature": 21.5,
+        },
+        blocking=True,
+    )
+    await hass.async_block_till_done()
+
+    climate_state = hass.states.get("climate.multi_zone_heating_living_room")
+    assert climate_state is not None
+    assert climate_state.attributes["temperature"] == 21.5
+    assert entry.data["zones"][0]["target_temperature"] == 21.5
+
+
+async def test_zone_climate_hvac_mode_toggles_zone_enabled(hass) -> None:
+    """Setting zone HVAC mode should enable and disable the owned zone."""
+    entry, _ = await _setup_loaded_entry(hass)
+
+    await hass.services.async_call(
+        "climate",
+        "set_hvac_mode",
+        {
+            ATTR_ENTITY_ID: "climate.multi_zone_heating_living_room",
+            "hvac_mode": "off",
+        },
+        blocking=True,
+    )
+    await hass.async_block_till_done()
+
+    climate_state = hass.states.get("climate.multi_zone_heating_living_room")
+    assert climate_state is not None
+    assert climate_state.state == "off"
+    assert entry.data["zones"][0]["enabled"] is False
+
+    await hass.services.async_call(
+        "climate",
+        "set_hvac_mode",
+        {
+            ATTR_ENTITY_ID: "climate.multi_zone_heating_living_room",
+            "hvac_mode": "heat",
+        },
+        blocking=True,
+    )
+    await hass.async_block_till_done()
+
+    climate_state = hass.states.get("climate.multi_zone_heating_living_room")
+    assert climate_state is not None
+    assert climate_state.state == "heat"
+    assert entry.data["zones"][0]["enabled"] is True
+
+
+async def test_zone_climate_target_restores_after_entry_reload(hass) -> None:
+    """Reloading the entry should restore the persisted owned zone target."""
+    entry, _ = await _setup_loaded_entry(hass)
+
+    await hass.services.async_call(
+        "climate",
+        "set_temperature",
+        {
+            ATTR_ENTITY_ID: "climate.multi_zone_heating_living_room",
+            "temperature": 21.5,
+        },
+        blocking=True,
+    )
+    await hass.async_block_till_done()
+
+    assert entry.data["zones"][0]["target_temperature"] == 21.5
+
+    assert await hass.config_entries.async_unload(entry.entry_id)
+    await hass.async_block_till_done()
+    assert await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    climate_state = hass.states.get("climate.multi_zone_heating_living_room")
+    assert climate_state is not None
+    assert climate_state.attributes["temperature"] == 21.5
+
+
 async def test_zone_target_change_clears_override(hass) -> None:
     """Clearing the override service should end the global override."""
     await _setup_loaded_entry(hass)
@@ -127,6 +218,127 @@ async def test_zone_target_change_clears_override(hass) -> None:
     assert climate_state is not None
     assert climate_state.attributes["override_active"] is False
     assert climate_state.attributes["override_target_temperature"] == 21.5
+
+
+async def test_zone_climate_current_temperature_uses_average_aggregation(hass) -> None:
+    """Zone climates should project the configured aggregated temperature."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        title="Multi-Zone Heating",
+        data={
+            "main_relay_entity_id": "switch.boiler",
+            "default_hysteresis": 0.3,
+            "zones": [
+                {
+                    "name": "Living Room",
+                    "enabled": True,
+                    "control_type": "climate",
+                    "target_temperature": 20.0,
+                    "sensor_entity_ids": [
+                        "sensor.living_room_temperature",
+                        "sensor.living_room_corner_temperature",
+                    ],
+                    "aggregation_mode": "average",
+                    "climate_entity_ids": [],
+                }
+            ],
+        },
+        version=1,
+    )
+    hass.states.async_set("sensor.living_room_temperature", "19.0")
+    hass.states.async_set("sensor.living_room_corner_temperature", "21.0")
+    hass.states.async_set("switch.boiler", STATE_OFF)
+
+    entry.add_to_hass(hass)
+    assert await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    climate_state = hass.states.get("climate.multi_zone_heating_living_room")
+    assert climate_state is not None
+    assert climate_state.attributes["current_temperature"] == 20.0
+    assert climate_state.attributes["aggregation_mode"] == "average"
+
+
+async def test_zone_climate_current_temperature_uses_primary_sensor(hass) -> None:
+    """Primary aggregation should expose the configured primary sensor directly."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        title="Multi-Zone Heating",
+        data={
+            "main_relay_entity_id": "switch.boiler",
+            "default_hysteresis": 0.3,
+            "zones": [
+                {
+                    "name": "Living Room",
+                    "enabled": True,
+                    "control_type": "climate",
+                    "target_temperature": 20.0,
+                    "sensor_entity_ids": [
+                        "sensor.living_room_temperature",
+                        "sensor.living_room_corner_temperature",
+                    ],
+                    "aggregation_mode": "primary",
+                    "primary_sensor_entity_id": "sensor.living_room_corner_temperature",
+                    "climate_entity_ids": [],
+                }
+            ],
+        },
+        version=1,
+    )
+    hass.states.async_set("sensor.living_room_temperature", "19.0")
+    hass.states.async_set("sensor.living_room_corner_temperature", "21.0")
+    hass.states.async_set("switch.boiler", STATE_OFF)
+
+    entry.add_to_hass(hass)
+    assert await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    climate_state = hass.states.get("climate.multi_zone_heating_living_room")
+    assert climate_state is not None
+    assert climate_state.attributes["current_temperature"] == 21.0
+    assert (
+        climate_state.attributes["primary_sensor_entity_id"]
+        == "sensor.living_room_corner_temperature"
+    )
+
+
+async def test_zone_climate_current_temperature_uses_minimum_aggregation(hass) -> None:
+    """Minimum aggregation should expose the coldest available sensor."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        title="Multi-Zone Heating",
+        data={
+            "main_relay_entity_id": "switch.boiler",
+            "default_hysteresis": 0.3,
+            "zones": [
+                {
+                    "name": "Living Room",
+                    "enabled": True,
+                    "control_type": "climate",
+                    "target_temperature": 20.0,
+                    "sensor_entity_ids": [
+                        "sensor.living_room_temperature",
+                        "sensor.living_room_corner_temperature",
+                    ],
+                    "aggregation_mode": "minimum",
+                    "climate_entity_ids": [],
+                }
+            ],
+        },
+        version=1,
+    )
+    hass.states.async_set("sensor.living_room_temperature", "19.0")
+    hass.states.async_set("sensor.living_room_corner_temperature", "21.0")
+    hass.states.async_set("switch.boiler", STATE_OFF)
+
+    entry.add_to_hass(hass)
+    assert await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    climate_state = hass.states.get("climate.multi_zone_heating_living_room")
+    assert climate_state is not None
+    assert climate_state.attributes["current_temperature"] == 19.0
+    assert climate_state.attributes["aggregation_mode"] == "minimum"
 
 
 async def test_zone_enable_and_global_force_off_switches_control_runtime(hass) -> None:

--- a/tests/components/multi_zone_heating/test_entities.py
+++ b/tests/components/multi_zone_heating/test_entities.py
@@ -1,4 +1,4 @@
-"""Tests for multi_zone_heating entities and override behavior."""
+"""Tests for multi_zone_heating entities and climate behavior."""
 
 from __future__ import annotations
 
@@ -71,14 +71,15 @@ async def _setup_loaded_entry(hass) -> tuple[MockConfigEntry, list[tuple[str, di
     return entry, calls
 
 
-async def test_system_climate_sets_and_clears_override(hass) -> None:
-    """The top-level climate entity should manage the global override."""
+async def test_system_climate_fans_target_out_to_owned_zone_targets(hass) -> None:
+    """The system climate should write through to the zone-owned targets."""
     await _setup_loaded_entry(hass)
 
     climate_state = hass.states.get("climate.multi_zone_heating_system")
     assert climate_state is not None
     assert climate_state.state == "heat"
-    assert climate_state.attributes["override_active"] is False
+    assert climate_state.attributes["temperature"] == 20.0
+    assert climate_state.attributes["zone_target_temperatures"] == {"Living Room": 20.0}
 
     await hass.services.async_call(
         "climate",
@@ -93,16 +94,76 @@ async def test_system_climate_sets_and_clears_override(hass) -> None:
 
     climate_state = hass.states.get("climate.multi_zone_heating_system")
     assert climate_state is not None
-    assert climate_state.attributes["override_active"] is True
-    assert climate_state.attributes["override_target_temperature"] == 21.5
+    assert climate_state.attributes["temperature"] == 21.5
+    assert climate_state.attributes["zone_target_temperatures"] == {"Living Room": 21.5}
 
-    await hass.services.async_call(DOMAIN, "clear_override", {}, blocking=True)
+    zone_state = hass.states.get("climate.multi_zone_heating_living_room")
+    assert zone_state is not None
+    assert zone_state.attributes["temperature"] == 21.5
+
+
+async def test_system_climate_reports_no_shared_target_when_zones_differ(hass) -> None:
+    """The system climate should not invent a separate target source."""
+    hass.states.async_set("sensor.living_room_temperature", "19.0")
+    hass.states.async_set("sensor.bedroom_temperature", "18.0")
+    hass.states.async_set("switch.living_room_radiator", STATE_OFF)
+    hass.states.async_set("switch.bedroom_radiator", STATE_OFF)
+    hass.states.async_set("switch.boiler", STATE_OFF)
+    _register_recording_switch_services(hass)
+
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        title="Multi-Zone Heating",
+        data={
+            "main_relay_entity_id": "switch.boiler",
+            "default_hysteresis": 0.3,
+            "relay_off_delay_seconds": 0,
+            "zones": [
+                {
+                    "name": "Living Room",
+                    "enabled": True,
+                    "control_type": "switch",
+                    "target_temperature": 20.0,
+                    "local_groups": [
+                        {
+                            "name": "Radiator",
+                            "control_type": "switch",
+                            "actuator_entity_ids": ["switch.living_room_radiator"],
+                            "sensor_entity_ids": ["sensor.living_room_temperature"],
+                            "aggregation_mode": "average",
+                        }
+                    ],
+                },
+                {
+                    "name": "Bedroom",
+                    "enabled": True,
+                    "control_type": "switch",
+                    "target_temperature": 18.5,
+                    "local_groups": [
+                        {
+                            "name": "Radiator",
+                            "control_type": "switch",
+                            "actuator_entity_ids": ["switch.bedroom_radiator"],
+                            "sensor_entity_ids": ["sensor.bedroom_temperature"],
+                            "aggregation_mode": "average",
+                        }
+                    ],
+                },
+            ],
+        },
+        version=1,
+    )
+    entry.add_to_hass(hass)
+    assert await hass.config_entries.async_setup(entry.entry_id)
     await hass.async_block_till_done()
 
     climate_state = hass.states.get("climate.multi_zone_heating_system")
     assert climate_state is not None
-    assert climate_state.attributes["override_active"] is False
-    assert climate_state.attributes["override_target_temperature"] == 21.5
+    assert climate_state.attributes["temperature"] is None
+    assert climate_state.attributes["zone_target_temperatures"] == {
+        "Living Room": 20.0,
+        "Bedroom": 18.5,
+    }
 
 
 async def test_zone_climate_exposes_and_persists_owned_target(hass) -> None:
@@ -196,28 +257,71 @@ async def test_zone_climate_target_restores_after_entry_reload(hass) -> None:
     assert climate_state.attributes["temperature"] == 21.5
 
 
-async def test_zone_target_change_clears_override(hass) -> None:
-    """Clearing the override service should end the global override."""
-    await _setup_loaded_entry(hass)
+async def test_system_climate_clamps_fanned_target_to_zone_frost_floor(hass) -> None:
+    """System fan-out should respect the strictest effective zone minimum."""
+    hass.states.async_set("sensor.living_room_temperature", "19.0")
+    hass.states.async_set("sensor.bedroom_temperature", "18.0")
+    hass.states.async_set("switch.living_room_radiator", STATE_OFF)
+    hass.states.async_set("switch.bedroom_radiator", STATE_OFF)
+    hass.states.async_set("switch.boiler", STATE_OFF)
+    _register_recording_switch_services(hass)
 
-    await hass.services.async_call(
-        "climate",
-        "set_temperature",
-        {
-            ATTR_ENTITY_ID: "climate.multi_zone_heating_system",
-            "temperature": 21.5,
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        title="Multi-Zone Heating",
+        data={
+            "main_relay_entity_id": "switch.boiler",
+            "default_hysteresis": 0.3,
+            "frost_protection_min_temp": 5.0,
+            "zones": [
+                {
+                    "name": "Living Room",
+                    "enabled": True,
+                    "control_type": "switch",
+                    "target_temperature": 20.0,
+                    "frost_protection_min_temp": 10.0,
+                    "local_groups": [
+                        {
+                            "name": "Radiator",
+                            "control_type": "switch",
+                            "actuator_entity_ids": ["switch.living_room_radiator"],
+                            "sensor_entity_ids": ["sensor.living_room_temperature"],
+                            "aggregation_mode": "average",
+                        }
+                    ],
+                },
+                {
+                    "name": "Bedroom",
+                    "enabled": True,
+                    "control_type": "switch",
+                    "target_temperature": 19.0,
+                    "local_groups": [
+                        {
+                            "name": "Radiator",
+                            "control_type": "switch",
+                            "actuator_entity_ids": ["switch.bedroom_radiator"],
+                            "sensor_entity_ids": ["sensor.bedroom_temperature"],
+                            "aggregation_mode": "average",
+                        }
+                    ],
+                },
+            ],
         },
-        blocking=True,
+        version=2,
     )
+    entry.add_to_hass(hass)
+    assert await hass.config_entries.async_setup(entry.entry_id)
     await hass.async_block_till_done()
 
-    await hass.services.async_call(DOMAIN, "clear_override", {}, blocking=True)
-    await hass.async_block_till_done()
+    system_state = hass.states.get("climate.multi_zone_heating_system")
+    assert system_state is not None
+    assert system_state.attributes["min_temp"] == 10.0
 
-    climate_state = hass.states.get("climate.multi_zone_heating_system")
-    assert climate_state is not None
-    assert climate_state.attributes["override_active"] is False
-    assert climate_state.attributes["override_target_temperature"] == 21.5
+    assert entry.runtime_data.coordinator is not None
+    await entry.runtime_data.coordinator.async_set_all_zone_target_temperatures(6.0)
+
+    assert entry.data["zones"][0]["target_temperature"] == 10.0
+    assert entry.data["zones"][1]["target_temperature"] == 6.0
 
 
 async def test_zone_climate_current_temperature_uses_average_aggregation(hass) -> None:
@@ -243,7 +347,7 @@ async def test_zone_climate_current_temperature_uses_average_aggregation(hass) -
                 }
             ],
         },
-        version=1,
+        version=2,
     )
     hass.states.async_set("sensor.living_room_temperature", "19.0")
     hass.states.async_set("sensor.living_room_corner_temperature", "21.0")
@@ -283,7 +387,7 @@ async def test_zone_climate_current_temperature_uses_primary_sensor(hass) -> Non
                 }
             ],
         },
-        version=1,
+        version=2,
     )
     hass.states.async_set("sensor.living_room_temperature", "19.0")
     hass.states.async_set("sensor.living_room_corner_temperature", "21.0")
@@ -325,7 +429,7 @@ async def test_zone_climate_current_temperature_uses_minimum_aggregation(hass) -
                 }
             ],
         },
-        version=1,
+        version=2,
     )
     hass.states.async_set("sensor.living_room_temperature", "19.0")
     hass.states.async_set("sensor.living_room_corner_temperature", "21.0")

--- a/tests/components/multi_zone_heating/test_entities.py
+++ b/tests/components/multi_zone_heating/test_entities.py
@@ -230,6 +230,44 @@ async def test_zone_climate_hvac_mode_toggles_zone_enabled(hass) -> None:
     assert entry.data["zones"][0]["enabled"] is True
 
 
+async def test_zone_enabled_switch_and_zone_climate_stay_synchronized(hass) -> None:
+    """Zone enable switch and climate HVAC mode should project the same state."""
+    await _setup_loaded_entry(hass)
+
+    await hass.services.async_call(
+        "switch",
+        "turn_off",
+        {"entity_id": "switch.multi_zone_heating_living_room_enabled"},
+        blocking=True,
+    )
+    await hass.async_block_till_done()
+
+    climate_state = hass.states.get("climate.multi_zone_heating_living_room")
+    switch_state = hass.states.get("switch.multi_zone_heating_living_room_enabled")
+    assert climate_state is not None
+    assert switch_state is not None
+    assert climate_state.state == "off"
+    assert switch_state.state == STATE_OFF
+
+    await hass.services.async_call(
+        "climate",
+        "set_hvac_mode",
+        {
+            ATTR_ENTITY_ID: "climate.multi_zone_heating_living_room",
+            "hvac_mode": "heat",
+        },
+        blocking=True,
+    )
+    await hass.async_block_till_done()
+
+    climate_state = hass.states.get("climate.multi_zone_heating_living_room")
+    switch_state = hass.states.get("switch.multi_zone_heating_living_room_enabled")
+    assert climate_state is not None
+    assert switch_state is not None
+    assert climate_state.state == "heat"
+    assert switch_state.state == STATE_ON
+
+
 async def test_zone_climate_target_restores_after_entry_reload(hass) -> None:
     """Reloading the entry should restore the persisted owned zone target."""
     entry, _ = await _setup_loaded_entry(hass)
@@ -481,6 +519,11 @@ async def test_zone_enable_and_global_force_off_switches_control_runtime(hass) -
     assert relay_state is not None
     assert relay_state.state == "forced_off"
 
+    zone_climate_state = hass.states.get("climate.multi_zone_heating_living_room")
+    assert zone_climate_state is not None
+    assert zone_climate_state.state == "off"
+    assert zone_climate_state.attributes["hvac_action"] == "off"
+
 
 async def test_zone_enable_toggle_persists_in_config_entry(hass) -> None:
     """Zone enable changes should update the config entry data."""
@@ -503,3 +546,26 @@ async def test_zone_enable_toggle_persists_in_config_entry(hass) -> None:
     )
     await hass.async_block_till_done()
     assert entry.data["zones"][0]["enabled"] is True
+
+
+async def test_zone_climate_keeps_heat_mode_but_reports_off_action_during_global_force_off(
+    hass,
+) -> None:
+    """Global force-off should not disable the zone, only suppress active heating."""
+    await _setup_loaded_entry(hass)
+
+    await hass.services.async_call(
+        "switch",
+        "turn_on",
+        {"entity_id": "switch.multi_zone_heating_global_force_off"},
+        blocking=True,
+    )
+    await hass.async_block_till_done()
+
+    climate_state = hass.states.get("climate.multi_zone_heating_living_room")
+    switch_state = hass.states.get("switch.multi_zone_heating_living_room_enabled")
+    assert climate_state is not None
+    assert switch_state is not None
+    assert climate_state.state == "heat"
+    assert climate_state.attributes["hvac_action"] == "off"
+    assert switch_state.state == STATE_ON

--- a/tests/components/multi_zone_heating/test_entities.py
+++ b/tests/components/multi_zone_heating/test_entities.py
@@ -23,8 +23,7 @@ def _build_config_entry() -> MockConfigEntry:
                     "name": "Living Room",
                     "enabled": True,
                     "control_type": "switch",
-                    "target_source": "input_number",
-                    "target_entity_id": "input_number.living_room_target",
+                    "target_temperature": 20.0,
                     "local_groups": [
                         {
                             "name": "Radiator",
@@ -61,7 +60,6 @@ def _register_recording_switch_services(hass) -> list[tuple[str, dict[str, str]]
 async def _setup_loaded_entry(hass) -> tuple[MockConfigEntry, list[tuple[str, dict[str, str]]]]:
     """Set up a config entry with states and switch service mocks."""
     hass.states.async_set("sensor.living_room_temperature", "19.0")
-    hass.states.async_set("input_number.living_room_target", "20.0")
     hass.states.async_set("switch.radiator", STATE_OFF)
     hass.states.async_set("switch.boiler", STATE_OFF)
 
@@ -108,7 +106,7 @@ async def test_system_climate_sets_and_clears_override(hass) -> None:
 
 
 async def test_zone_target_change_clears_override(hass) -> None:
-    """Changing a zone target should end the global override."""
+    """Clearing the override service should end the global override."""
     await _setup_loaded_entry(hass)
 
     await hass.services.async_call(
@@ -122,7 +120,7 @@ async def test_zone_target_change_clears_override(hass) -> None:
     )
     await hass.async_block_till_done()
 
-    hass.states.async_set("input_number.living_room_target", "19.0")
+    await hass.services.async_call(DOMAIN, "clear_override", {}, blocking=True)
     await hass.async_block_till_done()
 
     climate_state = hass.states.get("climate.multi_zone_heating_system")

--- a/tests/components/multi_zone_heating/test_init.py
+++ b/tests/components/multi_zone_heating/test_init.py
@@ -146,7 +146,7 @@ async def test_setup_migrates_legacy_zone_target_entities(hass) -> None:
 
 
 async def test_setup_rejects_legacy_zone_migration_without_usable_target(hass) -> None:
-    """Migration should fail when an old target entity has no readable value."""
+    """Migration should fall back to an owned default when the old target is unreadable."""
     config_entry = MockConfigEntry(
         domain=DOMAIN,
         title="Multi-Zone Heating",
@@ -171,10 +171,61 @@ async def test_setup_rejects_legacy_zone_migration_without_usable_target(hass) -
     )
     config_entry.add_to_hass(hass)
 
-    assert not await hass.config_entries.async_setup(config_entry.entry_id)
+    assert await hass.config_entries.async_setup(config_entry.entry_id)
     await hass.async_block_till_done()
 
-    assert config_entry.state is ConfigEntryState.MIGRATION_ERROR
+    assert config_entry.state is ConfigEntryState.LOADED
+    assert config_entry.version == 2
+    assert config_entry.data[CONF_ZONES][0][CONF_TARGET_TEMPERATURE] == 20.0
+
+
+async def test_zone_target_updates_persist_when_options_own_zones(hass) -> None:
+    """Runtime target changes should update options when options replace zone config."""
+    config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        title="Multi-Zone Heating",
+        data={
+            CONF_DEFAULT_HYSTERESIS: 0.3,
+            CONF_ZONES: [],
+        },
+        options={
+            CONF_DEFAULT_HYSTERESIS: 0.6,
+            CONF_ZONES: [
+                {
+                    CONF_NAME: "Living Room",
+                    CONF_ENABLED: True,
+                    CONF_CONTROL_TYPE: ControlType.CLIMATE,
+                    CONF_TARGET_TEMPERATURE: 20.0,
+                    CONF_SENSOR_ENTITY_IDS: ["sensor.living_room_temperature"],
+                    CONF_CLIMATE_ENTITY_IDS: [],
+                    CONF_LOCAL_GROUPS: [],
+                    CONF_AGGREGATION_MODE: AggregationMode.AVERAGE,
+                    CONF_PRIMARY_SENSOR_ENTITY_ID: None,
+                }
+            ],
+        },
+        version=2,
+        state=ConfigEntryState.NOT_LOADED,
+    )
+    hass.states.async_set("sensor.living_room_temperature", "19.0")
+    hass.states.async_set("switch.boiler", "off")
+    config_entry.add_to_hass(hass)
+
+    assert await hass.config_entries.async_setup(config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    await hass.services.async_call(
+        "climate",
+        "set_temperature",
+        {
+            "entity_id": "climate.multi_zone_heating_living_room",
+            "temperature": 21.5,
+        },
+        blocking=True,
+    )
+    await hass.async_block_till_done()
+
+    assert config_entry.options[CONF_ZONES][0][CONF_TARGET_TEMPERATURE] == 21.5
 
 
 async def test_setup_migrates_legacy_climate_target_entities(hass) -> None:

--- a/tests/components/multi_zone_heating/test_init.py
+++ b/tests/components/multi_zone_heating/test_init.py
@@ -17,8 +17,7 @@ from custom_components.multi_zone_heating.config_flow import (
     CONF_LOCAL_GROUPS,
     CONF_PRIMARY_SENSOR_ENTITY_ID,
     CONF_SENSOR_ENTITY_IDS,
-    CONF_TARGET_ENTITY_ID,
-    CONF_TARGET_SOURCE,
+    CONF_TARGET_TEMPERATURE,
     CONF_ZONES,
 )
 from custom_components.multi_zone_heating.coordinator import MultiZoneHeatingCoordinator
@@ -26,7 +25,6 @@ from custom_components.multi_zone_heating.models import (
     AggregationMode,
     ControlType,
     RuntimeData,
-    TargetSourceType,
 )
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
@@ -66,8 +64,7 @@ async def test_setup_entry_prefers_options_over_data(hass) -> None:
                     CONF_NAME: "Living Room",
                     CONF_ENABLED: True,
                     CONF_CONTROL_TYPE: ControlType.CLIMATE,
-                    CONF_TARGET_SOURCE: TargetSourceType.CLIMATE,
-                    CONF_TARGET_ENTITY_ID: "climate.living_room_target",
+                    CONF_TARGET_TEMPERATURE: 20.0,
                     CONF_SENSOR_ENTITY_IDS: ["sensor.living_room_temperature"],
                     CONF_CLIMATE_ENTITY_IDS: ["climate.living_room_radiator"],
                     CONF_LOCAL_GROUPS: [],
@@ -108,3 +105,147 @@ async def test_options_update_triggers_entry_reload(hass, config_entry) -> None:
         await hass.async_block_till_done()
 
     mock_reload.assert_awaited_once_with(config_entry.entry_id)
+
+
+async def test_setup_migrates_legacy_zone_target_entities(hass) -> None:
+    """Legacy target entity config should migrate to owned target temperatures."""
+    hass.states.async_set("input_number.living_room_target", "20.5")
+
+    config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        title="Multi-Zone Heating",
+        data={
+            CONF_ZONES: [
+                {
+                    CONF_NAME: "Living Room",
+                    CONF_ENABLED: True,
+                    CONF_CONTROL_TYPE: ControlType.CLIMATE,
+                    "target_source": "input_number",
+                    "target_entity_id": "input_number.living_room_target",
+                    CONF_SENSOR_ENTITY_IDS: ["sensor.living_room_temperature"],
+                    CONF_CLIMATE_ENTITY_IDS: ["climate.living_room_radiator"],
+                    CONF_LOCAL_GROUPS: [],
+                    CONF_AGGREGATION_MODE: AggregationMode.AVERAGE,
+                    CONF_PRIMARY_SENSOR_ENTITY_ID: None,
+                }
+            ],
+        },
+        version=1,
+        state=ConfigEntryState.NOT_LOADED,
+    )
+    config_entry.add_to_hass(hass)
+
+    assert await hass.config_entries.async_setup(config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert config_entry.version == 2
+    assert config_entry.data[CONF_ZONES][0][CONF_TARGET_TEMPERATURE] == 20.5
+    assert "target_source" not in config_entry.data[CONF_ZONES][0]
+    assert "target_entity_id" not in config_entry.data[CONF_ZONES][0]
+    assert config_entry.runtime_data.config.zones[0].target_temperature == 20.5
+
+
+async def test_setup_rejects_legacy_zone_migration_without_usable_target(hass) -> None:
+    """Migration should fail when an old target entity has no readable value."""
+    config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        title="Multi-Zone Heating",
+        data={
+            CONF_ZONES: [
+                {
+                    CONF_NAME: "Living Room",
+                    CONF_ENABLED: True,
+                    CONF_CONTROL_TYPE: ControlType.CLIMATE,
+                    "target_source": "input_number",
+                    "target_entity_id": "input_number.living_room_target",
+                    CONF_SENSOR_ENTITY_IDS: ["sensor.living_room_temperature"],
+                    CONF_CLIMATE_ENTITY_IDS: ["climate.living_room_radiator"],
+                    CONF_LOCAL_GROUPS: [],
+                    CONF_AGGREGATION_MODE: AggregationMode.AVERAGE,
+                    CONF_PRIMARY_SENSOR_ENTITY_ID: None,
+                }
+            ],
+        },
+        version=1,
+        state=ConfigEntryState.NOT_LOADED,
+    )
+    config_entry.add_to_hass(hass)
+
+    assert not await hass.config_entries.async_setup(config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert config_entry.state is ConfigEntryState.MIGRATION_ERROR
+
+
+async def test_setup_migrates_legacy_climate_target_entities(hass) -> None:
+    """Legacy climate target entities should migrate from their temperature attribute."""
+    hass.states.async_set(
+        "climate.living_room_target",
+        "heat",
+        {"temperature": 21.5},
+    )
+
+    config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        title="Multi-Zone Heating",
+        data={
+            CONF_ZONES: [
+                {
+                    CONF_NAME: "Living Room",
+                    CONF_ENABLED: True,
+                    CONF_CONTROL_TYPE: ControlType.CLIMATE,
+                    "target_source": "climate",
+                    "target_entity_id": "climate.living_room_target",
+                    CONF_SENSOR_ENTITY_IDS: ["sensor.living_room_temperature"],
+                    CONF_CLIMATE_ENTITY_IDS: ["climate.living_room_radiator"],
+                    CONF_LOCAL_GROUPS: [],
+                    CONF_AGGREGATION_MODE: AggregationMode.AVERAGE,
+                    CONF_PRIMARY_SENSOR_ENTITY_ID: None,
+                }
+            ],
+        },
+        version=1,
+        state=ConfigEntryState.NOT_LOADED,
+    )
+    config_entry.add_to_hass(hass)
+
+    assert await hass.config_entries.async_setup(config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert config_entry.data[CONF_ZONES][0][CONF_TARGET_TEMPERATURE] == 21.5
+
+
+async def test_setup_migration_applies_frost_floor_to_legacy_targets(hass) -> None:
+    """Legacy targets should migrate upward to the effective frost floor when needed."""
+    hass.states.async_set("input_number.living_room_target", "18.0")
+
+    config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        title="Multi-Zone Heating",
+        data={
+            "frost_protection_min_temp": 19.0,
+            CONF_ZONES: [
+                {
+                    CONF_NAME: "Living Room",
+                    CONF_ENABLED: True,
+                    CONF_CONTROL_TYPE: ControlType.CLIMATE,
+                    "target_source": "input_number",
+                    "target_entity_id": "input_number.living_room_target",
+                    "frost_protection_min_temp": 21.0,
+                    CONF_SENSOR_ENTITY_IDS: ["sensor.living_room_temperature"],
+                    CONF_CLIMATE_ENTITY_IDS: ["climate.living_room_radiator"],
+                    CONF_LOCAL_GROUPS: [],
+                    CONF_AGGREGATION_MODE: AggregationMode.AVERAGE,
+                    CONF_PRIMARY_SENSOR_ENTITY_ID: None,
+                }
+            ],
+        },
+        version=1,
+        state=ConfigEntryState.NOT_LOADED,
+    )
+    config_entry.add_to_hass(hass)
+
+    assert await hass.config_entries.async_setup(config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert config_entry.data[CONF_ZONES][0][CONF_TARGET_TEMPERATURE] == 21.0


### PR DESCRIPTION
## Summary
- update the design docs for zone-owned virtual climate entities and a strict master/slave model
- rewrite the user stories and implementation plan around integration-owned zone targets
- add implementation issue docs for the schema migration, zone climates, coordinator changes, and follow-up diagnostics/tests

## Why
The previous design depended on external target entities and mixed target ownership with downstream actuator state. These docs switch the integration to one virtual climate per zone, integration-owned target persistence, and coordinator dispatch to slave actuators only.

## Linked Issues
- Closes #27
- Closes #30
- Closes #28
- Closes #29

## Validation
- reviewed the updated markdown docs in-repo
- staged and committed only the intended documentation files
