### PR TITLE
[codex] Bump version to 0.3.0 and update docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 `multi_zone_heating` is a custom Home Assistant integration for coordinating multiple heating zones behind a shared main relay.
 
-Version `0.2.0` is the current release. It supports UI-based setup, climate- and actuator-driven zones, a shared relay, optional flow diagnostics, and a small set of runtime control entities for master commands and operations.
+Version `0.3.0` is the current release. It supports UI-based setup, climate- and actuator-driven zones, a shared relay, optional flow diagnostics, and a small set of runtime control entities for master commands and operations.
 
 ## Current Capabilities
 
@@ -59,4 +59,4 @@ Once configured, the integration creates:
 ## Notes
 
 - Home Assistant expects `custom_components/multi_zone_heating/strings.json` and `custom_components/multi_zone_heating/translations/en.json` to stay in sync. Update both files together when config-flow copy changes.
-- Version `0.2.0` is still intentionally narrow. The integration is usable, but the documentation also calls out current limits so users know what is and is not implemented yet.
+- Version `0.3.0` is still intentionally narrow. The integration is usable, but the documentation also calls out current limits so users know what is and is not implemented yet.

--- a/custom_components/multi_zone_heating/manifest.json
+++ b/custom_components/multi_zone_heating/manifest.json
@@ -4,10 +4,10 @@
   "codeowners": [],
   "config_flow": true,
   "dependencies": [],
-  "documentation": "https://github.com/jws/thermostat/blob/main/docs/installation-and-usage.md",
+  "documentation": "https://github.com/jspuij/multi_zone_heating/blob/main/docs/installation-and-usage.md",
   "integration_type": "hub",
   "iot_class": "local_push",
   "requirements": [],
   "single_config_entry": true,
-  "version": "0.2.0"
+  "version": "0.3.0"
 }

--- a/docs/installation-and-usage.md
+++ b/docs/installation-and-usage.md
@@ -6,7 +6,7 @@ This guide covers the current first version of the `multi_zone_heating` custom H
 
 The integration evaluates heat demand across multiple configured zones and coordinates a shared main relay for the whole heating system.
 
-In version `0.2.0`, it can:
+In version `0.3.0`, it can:
 
 - read one or more temperature sensors per zone or local control group
 - persist one owned target temperature per zone
@@ -94,7 +94,7 @@ During the first step, the integration asks for:
 
 Each zone has a name, an enabled flag, a control type, and an integration-owned target temperature.
 
-Supported zone control types in `0.2.0`:
+Supported zone control types in `0.3.0`:
 
 - `climate`
 - `switch`
@@ -166,7 +166,7 @@ A number zone is also built from one or more local control groups. For each grou
 - active value
 - inactive value
 
-In version `0.2.0`, both `active value` and `inactive value` are required.
+In version `0.3.0`, both `active value` and `inactive value` are required.
 
 Behavior:
 
@@ -279,7 +279,7 @@ Typical runtime usage is:
 
 ## First-Version Limitations
 
-Version `0.2.0` is usable, but it is still an early release. Current limits to document clearly:
+Version `0.3.0` is usable, but it is still an early release. Current limits to document clearly:
 
 - installation is documented as manual copy-based setup
 - the integration manages a single config entry for one heating system


### PR DESCRIPTION
## What changed
- bumped the integration version to `0.3.0`
- updated the README and installation guide so the current release references match `0.3.0`
- corrected the manifest documentation URL so Home Assistant points to this repository's installation guide

## Why
The published version metadata and user-facing docs were still pointing at `0.2.0`, and the manifest documentation link referenced a different repository.

## Impact
Users and Home Assistant now see the correct release version and land on the correct documentation page for this integration.

## Validation
- confirmed the diff only touches the intended documentation/version files
- searched the release-facing docs to verify the current version references are `0.3.0`
- no automated tests run because this is a docs/metadata-only change