### PR TITLE
[codex] docs: plan runtime persistence fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 `multi_zone_heating` is a custom Home Assistant integration for coordinating multiple heating zones behind a shared main relay.
 
-Version `0.3.0` is the current release. It supports UI-based setup, climate- and actuator-driven zones, a shared relay, optional flow diagnostics, and a small set of runtime control entities for master commands and operations.
+Version `0.3.1` is the current release. It supports UI-based setup, climate- and actuator-driven zones, a shared relay, optional flow diagnostics, and a small set of runtime control entities for master commands and operations.
 
 ## Current Capabilities
 
@@ -59,4 +59,4 @@ Once configured, the integration creates:
 ## Notes
 
 - Home Assistant expects `custom_components/multi_zone_heating/strings.json` and `custom_components/multi_zone_heating/translations/en.json` to stay in sync. Update both files together when config-flow copy changes.
-- Version `0.3.0` is still intentionally narrow. The integration is usable, but the documentation also calls out current limits so users know what is and is not implemented yet.
+- Version `0.3.1` is still intentionally narrow. The integration is usable, but the documentation also calls out current limits so users know what is and is not implemented yet.

--- a/custom_components/multi_zone_heating/__init__.py
+++ b/custom_components/multi_zone_heating/__init__.py
@@ -14,6 +14,7 @@ from .const import (
     CONFIG_ENTRY_VERSION,
     DOMAIN,
     PLATFORMS,
+    RELOAD_BOUNDARY_TERMINOLOGY,
 )
 from .coordinator import MultiZoneHeatingCoordinator, integration_config_from_dict
 from .models import RuntimeData
@@ -113,7 +114,12 @@ async def _async_update_listener(
     hass: HomeAssistant,
     entry: MultiZoneHeatingConfigEntry,
 ) -> None:
-    """Reload the entry when options change so runtime state stays in sync."""
+    """Reload the entry when structural options change."""
+    _LOGGER.debug(
+        "Reloading config entry %s after a structural options update (%s)",
+        entry.entry_id,
+        RELOAD_BOUNDARY_TERMINOLOGY,
+    )
     await hass.config_entries.async_reload(entry.entry_id)
 
 

--- a/custom_components/multi_zone_heating/__init__.py
+++ b/custom_components/multi_zone_heating/__init__.py
@@ -15,8 +15,9 @@ from .const import (
     DOMAIN,
     PLATFORMS,
 )
-from .models import RuntimeData
 from .coordinator import MultiZoneHeatingCoordinator, integration_config_from_dict
+from .models import RuntimeData
+from .runtime_state import RuntimeStateStore
 from .target_temperature import initial_zone_target_temperature
 
 if TYPE_CHECKING:
@@ -73,7 +74,14 @@ async def async_setup_entry(
     merged_config = deepcopy(dict(entry.data))
     merged_config.update(deepcopy(dict(entry.options)))
     config = integration_config_from_dict(merged_config)
-    coordinator = MultiZoneHeatingCoordinator(hass, config, config_entry=entry)
+    runtime_state_store = RuntimeStateStore(hass, entry.entry_id)
+    await runtime_state_store.async_apply_to_config(config)
+    coordinator = MultiZoneHeatingCoordinator(
+        hass,
+        config,
+        config_entry=entry,
+        runtime_state_store=runtime_state_store,
+    )
     entry.runtime_data = RuntimeData(
         config_entry_id=entry.entry_id,
         title=entry.title,
@@ -99,6 +107,8 @@ async def async_unload_entry(
             await coordinator.async_stop()
         hass.data.get(DOMAIN, {}).pop(entry.entry_id, None)
     return unloaded
+
+
 async def _async_update_listener(
     hass: HomeAssistant,
     entry: MultiZoneHeatingConfigEntry,
@@ -179,6 +189,8 @@ def _migrate_zone_data(
     migrated_zone.pop("target_source", None)
     migrated_zone.pop("target_entity_id", None)
     return migrated_zone
+
+
 def _read_legacy_target_temperature(
     hass: HomeAssistant,
     target_entity_id: object | None,

--- a/custom_components/multi_zone_heating/const.py
+++ b/custom_components/multi_zone_heating/const.py
@@ -9,6 +9,21 @@ NAME = "Multi-Zone Heating"
 DEFAULT_TITLE = NAME
 CONFIG_ENTRY_VERSION = 2
 DEFAULT_ZONE_TARGET_TEMPERATURE = 20.0
+RELOAD_BOUNDARY_TERMINOLOGY = "runtime-versus-structural"
+
+STRUCTURAL_RELOAD_EXAMPLES: tuple[str, ...] = (
+    "adding, removing, or renaming zones",
+    "changing zone control type",
+    "changing configured sensors, actuators, local groups, relay, or flow sensor bindings",
+    "changing global timing, flow, frost, or failsafe settings through the options flow",
+)
+
+RUNTIME_NO_RELOAD_EXAMPLES: tuple[str, ...] = (
+    "setting a zone climate target temperature",
+    "setting a zone climate hvac_mode to enable or disable a zone",
+    "setting the system climate target and fanning it out to zones",
+    "toggling global force-off",
+)
 
 PLATFORMS: tuple[Platform, ...] = (
     Platform.BINARY_SENSOR,

--- a/custom_components/multi_zone_heating/coordinator.py
+++ b/custom_components/multi_zone_heating/coordinator.py
@@ -43,6 +43,7 @@ from .models import (
     ZoneConfig,
     ZoneEvaluation,
 )
+from .runtime_state import RuntimeStateStore
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -125,6 +126,7 @@ class MultiZoneHeatingCoordinator(DataUpdateCoordinator[RuntimeSnapshot]):
         config: IntegrationConfig,
         *,
         config_entry: ConfigEntry | None = None,
+        runtime_state_store: RuntimeStateStore | None = None,
     ) -> None:
         """Initialize the coordinator."""
         try:
@@ -142,6 +144,7 @@ class MultiZoneHeatingCoordinator(DataUpdateCoordinator[RuntimeSnapshot]):
             )
             self.config_entry = config_entry
         self.config = config
+        self._runtime_state_store = runtime_state_store
         self._unsub_state_changes: CALLBACK_TYPE | None = None
         self._unsub_recheck: CALLBACK_TYPE | None = None
         self._last_zone_demands: dict[str, bool] = {}
@@ -193,7 +196,7 @@ class MultiZoneHeatingCoordinator(DataUpdateCoordinator[RuntimeSnapshot]):
             return
 
         zone.enabled = enabled
-        self._persist_zone_enabled(zone_name, enabled)
+        await self._async_persist_runtime_state()
         await self.async_refresh()
 
     async def async_set_zone_target_temperature(
@@ -211,7 +214,7 @@ class MultiZoneHeatingCoordinator(DataUpdateCoordinator[RuntimeSnapshot]):
             return
 
         zone.target_temperature = target_temperature
-        self._persist_zone_target_temperature(zone_name, target_temperature)
+        await self._async_persist_runtime_state()
         await self.async_refresh()
 
     async def async_set_all_zone_target_temperatures(self, target_temperature: float) -> None:
@@ -234,7 +237,7 @@ class MultiZoneHeatingCoordinator(DataUpdateCoordinator[RuntimeSnapshot]):
         if not changed_zone_temperatures:
             return
 
-        self._persist_zone_target_temperatures(changed_zone_temperatures)
+        await self._async_persist_runtime_state()
         await self.async_refresh()
 
     async def async_set_global_force_off(self, enabled: bool) -> None:
@@ -417,94 +420,12 @@ class MultiZoneHeatingCoordinator(DataUpdateCoordinator[RuntimeSnapshot]):
         snapshot.unavailable_entity_ids = sorted(unavailable_entity_ids)
         return snapshot
 
-    def _persist_zone_enabled(self, zone_name: str, enabled: bool) -> None:
-        """Persist the zone-enabled flag into the config entry data."""
-        if self.config_entry is None:
+    async def _async_persist_runtime_state(self) -> None:
+        """Persist runtime-owned zone state without reloading the config entry."""
+        if self._runtime_state_store is None:
             return
 
-        current_zones = self._config_entry_zone_payload()
-        zones = []
-        for zone_data in current_zones:
-            updated_zone_data = dict(zone_data)
-            if updated_zone_data.get("name") == zone_name:
-                updated_zone_data["enabled"] = enabled
-            zones.append(updated_zone_data)
-
-        self._persist_config_entry_zones(zones)
-
-    def _persist_zone_target_temperature(
-        self,
-        zone_name: str,
-        target_temperature: float,
-    ) -> None:
-        """Persist the owned zone target temperature into the config entry data."""
-        if self.config_entry is None:
-            return
-
-        current_zones = self._config_entry_zone_payload()
-        zones = []
-        for zone_data in current_zones:
-            updated_zone_data = dict(zone_data)
-            if updated_zone_data.get("name") == zone_name:
-                updated_zone_data["target_temperature"] = target_temperature
-            zones.append(updated_zone_data)
-
-        self._persist_config_entry_zones(zones)
-
-    def _persist_zone_target_temperatures(
-        self,
-        target_temperatures: Mapping[str, float],
-    ) -> None:
-        """Persist a set of zone target updates into the config entry."""
-        if self.config_entry is None:
-            return
-
-        current_zones = self._config_entry_zone_payload()
-        zones = []
-        for zone_data in current_zones:
-            updated_zone_data = dict(zone_data)
-            zone_name = updated_zone_data.get("name")
-            if zone_name in target_temperatures:
-                updated_zone_data["target_temperature"] = target_temperatures[zone_name]
-            zones.append(updated_zone_data)
-
-        self._persist_config_entry_zones(zones)
-
-    def _persist_config_entry_zones(self, zones: list[dict[str, Any]]) -> None:
-        """Persist zones to whichever config-entry payload currently owns them."""
-        if self.config_entry is None:
-            return
-
-        if "zones" in self.config_entry.options:
-            self.hass.config_entries.async_update_entry(
-                self.config_entry,
-                options={
-                    **self.config_entry.options,
-                    "zones": zones,
-                },
-            )
-            return
-
-        self.hass.config_entries.async_update_entry(
-            self.config_entry,
-            data={
-                **self.config_entry.data,
-                "zones": zones,
-            },
-        )
-
-    def _config_entry_zone_payload(self) -> list[dict[str, Any]]:
-        """Return the current zone payload, preferring options when they own it."""
-        if self.config_entry is None:
-            return []
-
-        zone_payload = self.config_entry.options.get("zones")
-        if isinstance(zone_payload, list):
-            return zone_payload
-        zone_payload = self.config_entry.data.get("zones")
-        if isinstance(zone_payload, list):
-            return zone_payload
-        return []
+        await self._runtime_state_store.async_save_zones(self.config.zones)
 
     def _clamp_zone_target_temperature(
         self,
@@ -757,6 +678,7 @@ class MultiZoneHeatingCoordinator(DataUpdateCoordinator[RuntimeSnapshot]):
         desired_hvac_mode: HVACMode,
     ) -> None:
         """Set a climate entity HVAC mode only when required."""
+        previous_hvac_mode: HVACMode | None = None
         current_hvac_mode = self._read_climate_hvac_mode(entity_id)
         if current_hvac_mode is not None:
             previous_hvac_mode = self._remember_observed_climate_hvac_mode(
@@ -774,7 +696,8 @@ class MultiZoneHeatingCoordinator(DataUpdateCoordinator[RuntimeSnapshot]):
 
         last_commanded = self._last_commanded_climate_hvac_modes.get(entity_id)
         if last_commanded == desired_hvac_mode:
-            return
+            if previous_hvac_mode is None or current_hvac_mode != previous_hvac_mode:
+                return
 
         await self.hass.services.async_call(
             CLIMATE_DOMAIN,

--- a/custom_components/multi_zone_heating/coordinator.py
+++ b/custom_components/multi_zone_heating/coordinator.py
@@ -44,6 +44,7 @@ from .models import (
     ZoneEvaluation,
 )
 from .runtime_state import RuntimeStateStore
+from .const import RELOAD_BOUNDARY_TERMINOLOGY
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -195,6 +196,12 @@ class MultiZoneHeatingCoordinator(DataUpdateCoordinator[RuntimeSnapshot]):
         if zone is None or zone.enabled == enabled:
             return
 
+        _LOGGER.debug(
+            "Applying runtime thermostat action without reload (%s): zone=%s enabled=%s",
+            RELOAD_BOUNDARY_TERMINOLOGY,
+            zone_name,
+            enabled,
+        )
         zone.enabled = enabled
         await self._async_persist_runtime_state()
         await self.async_refresh()
@@ -213,6 +220,12 @@ class MultiZoneHeatingCoordinator(DataUpdateCoordinator[RuntimeSnapshot]):
         if math.isclose(zone.target_temperature, target_temperature, abs_tol=0.01):
             return
 
+        _LOGGER.debug(
+            "Applying runtime thermostat action without reload (%s): zone=%s target_temperature=%s",
+            RELOAD_BOUNDARY_TERMINOLOGY,
+            zone_name,
+            target_temperature,
+        )
         zone.target_temperature = target_temperature
         await self._async_persist_runtime_state()
         await self.async_refresh()
@@ -237,6 +250,11 @@ class MultiZoneHeatingCoordinator(DataUpdateCoordinator[RuntimeSnapshot]):
         if not changed_zone_temperatures:
             return
 
+        _LOGGER.debug(
+            "Applying runtime thermostat action without reload (%s): system target fan-out=%s",
+            RELOAD_BOUNDARY_TERMINOLOGY,
+            changed_zone_temperatures,
+        )
         await self._async_persist_runtime_state()
         await self.async_refresh()
 
@@ -245,6 +263,11 @@ class MultiZoneHeatingCoordinator(DataUpdateCoordinator[RuntimeSnapshot]):
         if self._global_force_off == enabled:
             return
 
+        _LOGGER.debug(
+            "Applying runtime thermostat action without reload (%s): global_force_off=%s",
+            RELOAD_BOUNDARY_TERMINOLOGY,
+            enabled,
+        )
         self._global_force_off = enabled
         await self.async_refresh()
 

--- a/custom_components/multi_zone_heating/diagnostics.py
+++ b/custom_components/multi_zone_heating/diagnostics.py
@@ -10,6 +10,11 @@ from typing import Any
 from homeassistant.core import HomeAssistant
 
 from . import MultiZoneHeatingConfigEntry
+from .const import (
+    RELOAD_BOUNDARY_TERMINOLOGY,
+    RUNTIME_NO_RELOAD_EXAMPLES,
+    STRUCTURAL_RELOAD_EXAMPLES,
+)
 from .models import ZoneConfig, ZoneEvaluation
 
 
@@ -31,6 +36,11 @@ async def async_get_config_entry_diagnostics(
             "minor_version": entry.minor_version,
         },
         "config": _serialize_value(runtime_data.config if runtime_data is not None else dict(entry.data)),
+        "reload_boundaries": {
+            "terminology": RELOAD_BOUNDARY_TERMINOLOGY,
+            "structural_changes_reload": list(STRUCTURAL_RELOAD_EXAMPLES),
+            "runtime_actions_do_not_reload": list(RUNTIME_NO_RELOAD_EXAMPLES),
+        },
         "runtime": {
             "loaded": coordinator is not None,
             "global_force_off": coordinator.data.global_force_off

--- a/custom_components/multi_zone_heating/manifest.json
+++ b/custom_components/multi_zone_heating/manifest.json
@@ -9,5 +9,5 @@
   "iot_class": "local_push",
   "requirements": [],
   "single_config_entry": true,
-  "version": "0.3.0"
+  "version": "0.3.1"
 }

--- a/custom_components/multi_zone_heating/runtime_state.py
+++ b/custom_components/multi_zone_heating/runtime_state.py
@@ -1,0 +1,102 @@
+"""Runtime-owned state persistence for multi_zone_heating."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.storage import Store
+
+from .const import DOMAIN
+from .models import IntegrationConfig, ZoneConfig
+
+_STORAGE_VERSION = 1
+
+
+class RuntimeStateStore:
+    """Persist runtime-owned zone state outside config-entry reload paths."""
+
+    def __init__(self, hass: HomeAssistant, entry_id: str) -> None:
+        """Initialize the runtime state store for one config entry."""
+        self._store = Store[dict[str, Any]](
+            hass,
+            _STORAGE_VERSION,
+            f"{DOMAIN}.runtime_state.{entry_id}",
+        )
+
+    async def async_apply_to_config(self, config: IntegrationConfig) -> None:
+        """Overlay persisted runtime-owned state onto the in-memory config."""
+        zones = await self.async_load()
+        if not zones:
+            return
+
+        for zone in config.zones:
+            self._apply_zone_state(zone, zones.get(zone.name))
+
+    async def async_load(self) -> dict[str, dict[str, Any]]:
+        """Load the persisted zone state payload."""
+        payload = await self._store.async_load()
+        if not isinstance(payload, dict):
+            return {}
+
+        zones = payload.get("zones")
+        if not isinstance(zones, dict):
+            return {}
+
+        return {
+            str(zone_name): dict(zone_state)
+            for zone_name, zone_state in zones.items()
+            if isinstance(zone_state, Mapping)
+        }
+
+    async def async_save_zones(self, zones: list[ZoneConfig]) -> None:
+        """Persist the current runtime-owned state for all configured zones."""
+        await self.async_save_zone_state_map(
+            {
+                zone.name: {
+                    "target_temperature": zone.target_temperature,
+                    "enabled": zone.enabled,
+                }
+                for zone in zones
+            }
+        )
+
+    async def async_save_zone_state_map(
+        self,
+        zones: Mapping[str, Mapping[str, Any]],
+    ) -> None:
+        """Persist a prebuilt zone state payload."""
+        await self._store.async_save(
+            {
+                "zones": {str(zone_name): dict(zone_state) for zone_name, zone_state in zones.items()}
+            }
+        )
+
+    def _apply_zone_state(
+        self,
+        zone: ZoneConfig,
+        zone_state: Mapping[str, Any] | None,
+    ) -> None:
+        """Apply one stored zone state record to a runtime config zone."""
+        if zone_state is None:
+            return
+
+        target_temperature = _coerce_float(zone_state.get("target_temperature"))
+        if target_temperature is not None:
+            zone.target_temperature = target_temperature
+
+        enabled = zone_state.get("enabled")
+        if isinstance(enabled, bool):
+            zone.enabled = enabled
+
+
+def _coerce_float(value: object) -> float | None:
+    """Convert a persisted numeric value into a float when possible."""
+    if value is None:
+        return None
+
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None

--- a/docs/implementation-plan.md
+++ b/docs/implementation-plan.md
@@ -64,6 +64,25 @@ Recommended order:
 7. Add top-level climate behavior aligned with the new model
 8. Finish options flow, diagnostics polish, and tests
 
+## Runtime Persistence Fix Plan
+
+The current runtime bug shows that zone climate target and enable changes are being persisted through config-entry updates, which causes the integration to reload and briefly drop its entities. The fix should separate structural configuration from runtime-owned thermostat state.
+
+Recommended sequence:
+
+1. Define reload boundaries explicitly.
+   Structural edits made through the options flow should continue to reload the integration. Runtime climate actions such as zone target changes, zone enable or disable, and system target fan-out must not trigger config-entry reloads.
+2. Introduce a runtime-owned persistence layer.
+   Move per-zone target temperature and zone enabled state out of config-entry update paths. Persist them in integration-managed runtime storage that survives restart without requiring entry reload.
+3. Restore runtime-owned state during startup.
+   On setup, load persisted zone targets and enabled flags before entities are added so the virtual climates come up with stable state immediately.
+4. Keep config-entry payloads structural only.
+   The config entry should continue to describe zone topology, entity bindings, timing rules, frost settings, and other wiring data, but not mutable thermostat operating state.
+5. Narrow reload behavior to structural edits.
+   Update the config-entry listener and related flows so that reloads still happen after zone topology or global setting edits, but not after runtime thermostat commands.
+6. Add regression coverage around entity availability.
+   Tests should verify that changing a zone target, zone HVAC mode, or system target does not unload climate entities or surface `Unavailable`, while structural options edits still reload as expected.
+
 ## Milestones
 
 ### Milestone 1: Schema And Migration
@@ -220,7 +239,16 @@ Related stories:
 - Use Home Assistant config flow and options flow only
 - Do not write YAML configuration files
 - Persist user configuration in config entries
-- Persist zone-owned target temperatures in integration-managed state or config
+- Persist zone-owned target temperatures and zone enabled state in integration-managed runtime storage
+- Keep config entries limited to structural configuration that defines setup, subscriptions, and entity topology
+
+### Reload Boundaries
+
+- Reload the entry when structural configuration changes
+- Structural changes include zone additions or removals, zone renames, control-type changes, sensor or actuator membership changes, local-group edits, relay or flow entity changes, and global timing or safety settings changed through the options flow
+- Do not reload the entry for runtime thermostat actions
+- Runtime actions include zone target changes, zone HVAC mode changes that map to enable or disable, system climate target fan-out, and global force-off toggles
+- Runtime actions must update entity state in place and persist without unloading platforms
 
 ### Zone Climate Ownership
 
@@ -229,6 +257,7 @@ Related stories:
 - External climate entities, if configured, are slave actuators only
 - The coordinator must not read target temperature from slave entities
 - The zone climate `hvac_mode` is the canonical enabled or disabled state for the zone
+- Zone target and enabled-state writes must not go through config-entry reload paths
 
 ### Zone Climate Temperature Presentation
 

--- a/docs/installation-and-usage.md
+++ b/docs/installation-and-usage.md
@@ -224,7 +224,7 @@ Attributes include:
 - `switch.<entry>_<zone>_enabled`
   - enables or disables one configured zone
 
-Zone enabled state is persisted back into the config entry, so it survives reloads.
+Zone target and enabled state are runtime-owned integration state. They should survive restart, but changing them should not reload the integration or make the virtual climate briefly unavailable.
 
 ### Sensor
 
@@ -284,6 +284,7 @@ Version `0.3.0` is usable, but it is still an early release. Current limits to d
 - installation is documented as manual copy-based setup
 - the integration manages a single config entry for one heating system
 - zone targets are stored by the integration instead of external helper or climate entities
+- runtime thermostat actions currently still trigger a full integration reload; this should be removed so virtual climates stay available during adjustments
 - dedicated `number` platform entities are not exposed yet, even though number actuators are supported
 - documentation screenshots are placeholders for now
 

--- a/docs/installation-and-usage.md
+++ b/docs/installation-and-usage.md
@@ -6,7 +6,7 @@ This guide covers the current first version of the `multi_zone_heating` custom H
 
 The integration evaluates heat demand across multiple configured zones and coordinates a shared main relay for the whole heating system.
 
-In version `0.3.0`, it can:
+In version `0.3.1`, it can:
 
 - read one or more temperature sensors per zone or local control group
 - persist one owned target temperature per zone
@@ -94,7 +94,7 @@ During the first step, the integration asks for:
 
 Each zone has a name, an enabled flag, a control type, and an integration-owned target temperature.
 
-Supported zone control types in `0.3.0`:
+Supported zone control types in `0.3.1`:
 
 - `climate`
 - `switch`
@@ -166,7 +166,7 @@ A number zone is also built from one or more local control groups. For each grou
 - active value
 - inactive value
 
-In version `0.3.0`, both `active value` and `inactive value` are required.
+In version `0.3.1`, both `active value` and `inactive value` are required.
 
 Behavior:
 
@@ -279,7 +279,7 @@ Typical runtime usage is:
 
 ## First-Version Limitations
 
-Version `0.3.0` is usable, but it is still an early release. Current limits to document clearly:
+Version `0.3.1` is usable, but it is still an early release. Current limits to document clearly:
 
 - installation is documented as manual copy-based setup
 - the integration manages a single config entry for one heating system

--- a/docs/installation-and-usage.md
+++ b/docs/installation-and-usage.md
@@ -284,9 +284,30 @@ Version `0.3.0` is usable, but it is still an early release. Current limits to d
 - installation is documented as manual copy-based setup
 - the integration manages a single config entry for one heating system
 - zone targets are stored by the integration instead of external helper or climate entities
-- runtime thermostat actions currently still trigger a full integration reload; this should be removed so virtual climates stay available during adjustments
+- structural configuration edits still reload the integration, but runtime thermostat actions update in place without unloading entities
 - dedicated `number` platform entities are not exposed yet, even though number actuators are supported
 - documentation screenshots are placeholders for now
+
+### Reload Boundaries
+
+The integration uses a runtime-versus-structural boundary:
+
+- structural options edits reload the integration because they change topology, subscriptions, or coordinator wiring
+- runtime thermostat actions update in place and persist without reloading the config entry
+
+Structural examples:
+
+- adding, removing, or renaming zones
+- changing zone control type
+- changing configured sensors, actuators, local groups, relay, or flow sensor bindings
+- changing global timing, flow, frost, or failsafe settings through the options flow
+
+Runtime examples:
+
+- setting a zone climate target temperature
+- setting a zone climate `hvac_mode` to enable or disable a zone
+- setting the system climate target and fanning it out to zones
+- toggling global force-off
 
 ## Troubleshooting
 

--- a/docs/integration-design.md
+++ b/docs/integration-design.md
@@ -95,7 +95,7 @@ If no valid sensor remains, the zone climate reports no `current_temperature` an
 
 ### Zone Target Ownership
 
-Each zone target temperature is persisted in integration-owned state or config.
+Each zone target temperature is persisted in integration-owned runtime state, separate from structural config-entry data.
 
 Implications:
 
@@ -103,6 +103,27 @@ Implications:
 - A zone target is read from the zone virtual climate state only
 - Target changes made through the zone climate must survive restart
 - External Home Assistant entities may still automate the zone climate, but are not part of core zone config
+- Target writes must not trigger config-entry reloads
+
+### Reload Boundaries
+
+Structural configuration changes should reload the integration because they change entity topology, subscriptions, or coordinator wiring.
+
+Examples:
+
+- adding, removing, or renaming zones
+- changing zone control type
+- changing configured sensors, actuators, local groups, relay, or flow sensor bindings
+- changing global timing, flow, frost, or failsafe settings that are read during setup
+
+Runtime thermostat actions should not reload the integration.
+
+Examples:
+
+- setting a zone climate target temperature
+- setting a zone climate `hvac_mode` to enable or disable a zone
+- setting the system climate target and fanning it out to zones
+- toggling global force-off
 
 ### Zone Demand
 
@@ -393,6 +414,7 @@ Master / slave behavior:
 - The coordinator reads zone targets from zone climate state only
 - Downstream actuators never provide target input
 - Setting the system climate target may fan out to zone climates, but zone climates remain the only per-zone source of truth
+- These runtime writes must update state in place without unloading the integration
 
 Recommended attributes:
 

--- a/docs/issues/ISSUE-018-runtime-state-persistence-without-reload.md
+++ b/docs/issues/ISSUE-018-runtime-state-persistence-without-reload.md
@@ -1,0 +1,42 @@
+# ISSUE-018 Runtime State Persistence Without Reload
+
+## Goal
+
+Persist runtime-owned thermostat state without reloading the integration when users operate the virtual climate entities.
+
+## Scope
+
+- Introduce integration-managed persistence for per-zone target temperature
+- Introduce integration-managed persistence for per-zone enabled state
+- Restore that runtime-owned state during startup before entity setup completes
+- Update coordinator write paths so zone climate and system climate actions no longer call config-entry update flows for runtime state
+- Keep entity state updates local and immediate after runtime writes
+
+## Why
+
+Zone climate writes currently persist through config-entry updates, and the config-entry update listener reloads the whole integration. That unloads the climate platforms and causes the UI to show `Unavailable` for several seconds after a thermostat adjustment.
+
+## Related Stories
+
+- US-005
+- US-017
+- US-020
+- US-021
+
+## Acceptance Criteria
+
+- Changing a zone virtual climate target does not reload the config entry
+- Changing zone `hvac_mode` between `heat` and `off` does not reload the config entry
+- Changing the system climate target does not reload the config entry
+- Runtime-owned zone target and enabled state survive Home Assistant restart
+- Virtual climate entities remain available while runtime-owned state is being updated
+
+## Dependencies
+
+- ISSUE-013
+- ISSUE-017
+
+## Out Of Scope
+
+- Redesigning the options flow
+- Changing slave climate dispatch semantics

--- a/docs/issues/ISSUE-019-reload-boundaries-and-runtime-regression-coverage.md
+++ b/docs/issues/ISSUE-019-reload-boundaries-and-runtime-regression-coverage.md
@@ -1,0 +1,42 @@
+# ISSUE-019 Reload Boundaries And Runtime Regression Coverage
+
+## Goal
+
+Define and enforce which edits should reload the integration and add regression coverage so runtime thermostat actions never regress back to reload-driven behavior.
+
+## Scope
+
+- Document the structural edits that require config-entry reload
+- Restrict reload-triggering behavior to structural config changes
+- Keep options-flow edits that change topology or wiring on the reload path
+- Add tests that prove runtime thermostat actions do not unload entity platforms
+- Add tests that prove structural options edits still reload the integration
+- Add diagnostics or debug output where helpful to distinguish structural reloads from runtime state writes
+
+## Why
+
+Without explicit reload boundaries, runtime-owned climate actions can accidentally reuse config-entry update machinery and reintroduce temporary entity unavailability. The integration needs both a policy and regression tests that lock the intended behavior in place.
+
+## Related Stories
+
+- US-017
+- US-020
+- US-026
+
+## Acceptance Criteria
+
+- Structural options edits still reload the integration
+- Runtime thermostat actions do not reload the integration
+- Tests cover zone target updates, zone enable or disable updates, and system target fan-out without entity unload
+- Tests cover at least one structural edit path that still reloads correctly
+- Documentation and diagnostics use the same runtime-versus-structural terminology
+
+## Dependencies
+
+- ISSUE-008
+- ISSUE-018
+
+## Out Of Scope
+
+- New user-facing control entities
+- Broader diagnostics redesign beyond what is needed for reload-boundary visibility

--- a/tests/components/multi_zone_heating/test_coordinator.py
+++ b/tests/components/multi_zone_heating/test_coordinator.py
@@ -527,6 +527,53 @@ async def test_coordinator_turns_climate_zone_off_when_global_force_off_is_enabl
     await coordinator.async_stop()
 
 
+async def test_coordinator_retries_climate_off_when_slave_state_does_not_change(hass) -> None:
+    """Forced-off climate commands should be retried until the slave state reflects them."""
+    hass.states.async_set("sensor.living_room_temperature", "19.0")
+    hass.states.async_set(
+        "climate.radiator_a",
+        "heat",
+        {"temperature": 20.0, "hvac_modes": [HVACMode.HEAT, HVACMode.OFF]},
+    )
+    hass.states.async_set("switch.boiler", "off")
+    _register_recording_switch_services(hass)
+
+    hvac_mode_calls: list[dict[str, object]] = []
+
+    async def _record_set_temperature_noop(call: ServiceCall) -> None:
+        del call
+
+    async def _record_set_hvac_mode_without_state_change(call: ServiceCall) -> None:
+        hvac_mode_calls.append(dict(call.data))
+
+    hass.services.async_register("climate", SERVICE_SET_TEMPERATURE, _record_set_temperature_noop)
+    hass.services.async_register(
+        "climate",
+        SERVICE_SET_HVAC_MODE,
+        _record_set_hvac_mode_without_state_change,
+    )
+
+    coordinator = MultiZoneHeatingCoordinator(hass, _build_climate_config())
+    await coordinator.async_start()
+    await hass.async_block_till_done()
+
+    hvac_mode_calls.clear()
+
+    await coordinator.async_set_global_force_off(True)
+    await hass.async_block_till_done()
+
+    assert hvac_mode_calls == [{"entity_id": "climate.radiator_a", ATTR_HVAC_MODE: HVACMode.OFF}]
+
+    await coordinator.async_request_refresh()
+    await hass.async_block_till_done()
+
+    assert hvac_mode_calls == [
+        {"entity_id": "climate.radiator_a", ATTR_HVAC_MODE: HVACMode.OFF},
+        {"entity_id": "climate.radiator_a", ATTR_HVAC_MODE: HVACMode.OFF},
+    ]
+    await coordinator.async_stop()
+
+
 async def test_coordinator_restores_climate_zone_heat_when_global_force_off_is_cleared(
     hass,
 ) -> None:

--- a/tests/components/multi_zone_heating/test_diagnostics.py
+++ b/tests/components/multi_zone_heating/test_diagnostics.py
@@ -78,6 +78,15 @@ async def test_config_entry_diagnostics_include_config_and_runtime_state(hass) -
     assert diagnostics["config_entry"]["version"] == 2
     assert diagnostics["config"]["main_relay_entity_id"] == "switch.boiler"
     assert diagnostics["config"]["zones"][0]["control_type"] == "switch"
+    assert diagnostics["reload_boundaries"]["terminology"] == "runtime-versus-structural"
+    assert (
+        "changing global timing, flow, frost, or failsafe settings through the options flow"
+        in diagnostics["reload_boundaries"]["structural_changes_reload"]
+    )
+    assert (
+        "setting the system climate target and fanning it out to zones"
+        in diagnostics["reload_boundaries"]["runtime_actions_do_not_reload"]
+    )
     assert diagnostics["runtime"]["loaded"] is True
     assert diagnostics["runtime"]["global_force_off"] is False
     assert diagnostics["runtime"]["system_climate"]["hvac_mode"] == "heat"

--- a/tests/components/multi_zone_heating/test_entities.py
+++ b/tests/components/multi_zone_heating/test_entities.py
@@ -2,11 +2,14 @@
 
 from __future__ import annotations
 
+from unittest.mock import AsyncMock, patch
+
 from homeassistant.const import ATTR_ENTITY_ID, STATE_OFF, STATE_ON
 from homeassistant.core import ServiceCall
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
 from custom_components.multi_zone_heating.const import DOMAIN
+from custom_components.multi_zone_heating.runtime_state import RuntimeStateStore
 
 
 def _build_config_entry() -> MockConfigEntry:
@@ -69,6 +72,11 @@ async def _setup_loaded_entry(hass) -> tuple[MockConfigEntry, list[tuple[str, di
     assert await hass.config_entries.async_setup(entry.entry_id)
     await hass.async_block_till_done()
     return entry, calls
+
+
+async def _load_runtime_zone_state(hass, entry: MockConfigEntry) -> dict[str, dict[str, object]]:
+    """Load the persisted runtime zone state for one config entry."""
+    return await RuntimeStateStore(hass, entry.entry_id).async_load()
 
 
 async def test_system_climate_fans_target_out_to_owned_zone_targets(hass) -> None:
@@ -190,7 +198,14 @@ async def test_zone_climate_exposes_and_persists_owned_target(hass) -> None:
     climate_state = hass.states.get("climate.multi_zone_heating_living_room")
     assert climate_state is not None
     assert climate_state.attributes["temperature"] == 21.5
-    assert entry.data["zones"][0]["target_temperature"] == 21.5
+    assert entry.data["zones"][0]["target_temperature"] == 20.0
+    assert entry.runtime_data.config.zones[0].target_temperature == 21.5
+    assert await _load_runtime_zone_state(hass, entry) == {
+        "Living Room": {
+            "target_temperature": 21.5,
+            "enabled": True,
+        }
+    }
 
 
 async def test_zone_climate_hvac_mode_toggles_zone_enabled(hass) -> None:
@@ -211,7 +226,14 @@ async def test_zone_climate_hvac_mode_toggles_zone_enabled(hass) -> None:
     climate_state = hass.states.get("climate.multi_zone_heating_living_room")
     assert climate_state is not None
     assert climate_state.state == "off"
-    assert entry.data["zones"][0]["enabled"] is False
+    assert entry.data["zones"][0]["enabled"] is True
+    assert entry.runtime_data.config.zones[0].enabled is False
+    assert await _load_runtime_zone_state(hass, entry) == {
+        "Living Room": {
+            "target_temperature": 20.0,
+            "enabled": False,
+        }
+    }
 
     await hass.services.async_call(
         "climate",
@@ -228,6 +250,13 @@ async def test_zone_climate_hvac_mode_toggles_zone_enabled(hass) -> None:
     assert climate_state is not None
     assert climate_state.state == "heat"
     assert entry.data["zones"][0]["enabled"] is True
+    assert entry.runtime_data.config.zones[0].enabled is True
+    assert await _load_runtime_zone_state(hass, entry) == {
+        "Living Room": {
+            "target_temperature": 20.0,
+            "enabled": True,
+        }
+    }
 
 
 async def test_zone_enabled_switch_and_zone_climate_stay_synchronized(hass) -> None:
@@ -283,7 +312,13 @@ async def test_zone_climate_target_restores_after_entry_reload(hass) -> None:
     )
     await hass.async_block_till_done()
 
-    assert entry.data["zones"][0]["target_temperature"] == 21.5
+    assert entry.data["zones"][0]["target_temperature"] == 20.0
+    assert await _load_runtime_zone_state(hass, entry) == {
+        "Living Room": {
+            "target_temperature": 21.5,
+            "enabled": True,
+        }
+    }
 
     assert await hass.config_entries.async_unload(entry.entry_id)
     await hass.async_block_till_done()
@@ -292,6 +327,43 @@ async def test_zone_climate_target_restores_after_entry_reload(hass) -> None:
 
     climate_state = hass.states.get("climate.multi_zone_heating_living_room")
     assert climate_state is not None
+    assert climate_state.attributes["temperature"] == 21.5
+
+
+async def test_runtime_climate_writes_do_not_reload_or_unload_entities(hass) -> None:
+    """Runtime thermostat writes should keep the integration loaded and available."""
+    entry, _ = await _setup_loaded_entry(hass)
+
+    with patch.object(
+        hass.config_entries,
+        "async_reload",
+        AsyncMock(return_value=True),
+    ) as mock_reload:
+        await hass.services.async_call(
+            "climate",
+            "set_temperature",
+            {
+                ATTR_ENTITY_ID: "climate.multi_zone_heating_living_room",
+                "temperature": 21.5,
+            },
+            blocking=True,
+        )
+        await hass.services.async_call(
+            "climate",
+            "set_hvac_mode",
+            {
+                ATTR_ENTITY_ID: "climate.multi_zone_heating_living_room",
+                "hvac_mode": "off",
+            },
+            blocking=True,
+        )
+        await hass.async_block_till_done()
+
+    mock_reload.assert_not_awaited()
+
+    climate_state = hass.states.get("climate.multi_zone_heating_living_room")
+    assert climate_state is not None
+    assert climate_state.state == "off"
     assert climate_state.attributes["temperature"] == 21.5
 
 
@@ -358,8 +430,19 @@ async def test_system_climate_clamps_fanned_target_to_zone_frost_floor(hass) -> 
     assert entry.runtime_data.coordinator is not None
     await entry.runtime_data.coordinator.async_set_all_zone_target_temperatures(6.0)
 
-    assert entry.data["zones"][0]["target_temperature"] == 10.0
-    assert entry.data["zones"][1]["target_temperature"] == 6.0
+    assert entry.data["zones"][0]["target_temperature"] == 20.0
+    assert entry.data["zones"][1]["target_temperature"] == 19.0
+    assert [zone.target_temperature for zone in entry.runtime_data.config.zones] == [10.0, 6.0]
+    assert await _load_runtime_zone_state(hass, entry) == {
+        "Living Room": {
+            "target_temperature": 10.0,
+            "enabled": True,
+        },
+        "Bedroom": {
+            "target_temperature": 6.0,
+            "enabled": True,
+        },
+    }
 
 
 async def test_zone_climate_current_temperature_uses_average_aggregation(hass) -> None:
@@ -501,7 +584,14 @@ async def test_zone_enable_and_global_force_off_switches_control_runtime(hass) -
     assert zone_state.state == STATE_OFF
     assert system_state is not None
     assert system_state.state == STATE_OFF
-    assert entry.data["zones"][0]["enabled"] is False
+    assert entry.data["zones"][0]["enabled"] is True
+    assert entry.runtime_data.config.zones[0].enabled is False
+    assert await _load_runtime_zone_state(hass, entry) == {
+        "Living Room": {
+            "target_temperature": 20.0,
+            "enabled": False,
+        }
+    }
 
     await hass.services.async_call(
         "switch",
@@ -525,8 +615,8 @@ async def test_zone_enable_and_global_force_off_switches_control_runtime(hass) -
     assert zone_climate_state.attributes["hvac_action"] == "off"
 
 
-async def test_zone_enable_toggle_persists_in_config_entry(hass) -> None:
-    """Zone enable changes should update the config entry data."""
+async def test_zone_enable_toggle_persists_in_runtime_store(hass) -> None:
+    """Zone enable changes should persist without mutating the config entry."""
     entry, _ = await _setup_loaded_entry(hass)
 
     await hass.services.async_call(
@@ -536,7 +626,14 @@ async def test_zone_enable_toggle_persists_in_config_entry(hass) -> None:
         blocking=True,
     )
     await hass.async_block_till_done()
-    assert entry.data["zones"][0]["enabled"] is False
+    assert entry.data["zones"][0]["enabled"] is True
+    assert entry.runtime_data.config.zones[0].enabled is False
+    assert await _load_runtime_zone_state(hass, entry) == {
+        "Living Room": {
+            "target_temperature": 20.0,
+            "enabled": False,
+        }
+    }
 
     await hass.services.async_call(
         "switch",
@@ -546,6 +643,13 @@ async def test_zone_enable_toggle_persists_in_config_entry(hass) -> None:
     )
     await hass.async_block_till_done()
     assert entry.data["zones"][0]["enabled"] is True
+    assert entry.runtime_data.config.zones[0].enabled is True
+    assert await _load_runtime_zone_state(hass, entry) == {
+        "Living Room": {
+            "target_temperature": 20.0,
+            "enabled": True,
+        }
+    }
 
 
 async def test_zone_climate_keeps_heat_mode_but_reports_off_action_during_global_force_off(

--- a/tests/components/multi_zone_heating/test_entities.py
+++ b/tests/components/multi_zone_heating/test_entities.py
@@ -334,11 +334,18 @@ async def test_runtime_climate_writes_do_not_reload_or_unload_entities(hass) -> 
     """Runtime thermostat writes should keep the integration loaded and available."""
     entry, _ = await _setup_loaded_entry(hass)
 
-    with patch.object(
-        hass.config_entries,
-        "async_reload",
-        AsyncMock(return_value=True),
-    ) as mock_reload:
+    with (
+        patch.object(
+            hass.config_entries,
+            "async_reload",
+            AsyncMock(return_value=True),
+        ) as mock_reload,
+        patch.object(
+            hass.config_entries,
+            "async_unload_platforms",
+            AsyncMock(return_value=True),
+        ) as mock_unload_platforms,
+    ):
         await hass.services.async_call(
             "climate",
             "set_temperature",
@@ -360,11 +367,53 @@ async def test_runtime_climate_writes_do_not_reload_or_unload_entities(hass) -> 
         await hass.async_block_till_done()
 
     mock_reload.assert_not_awaited()
+    mock_unload_platforms.assert_not_awaited()
 
     climate_state = hass.states.get("climate.multi_zone_heating_living_room")
     assert climate_state is not None
     assert climate_state.state == "off"
     assert climate_state.attributes["temperature"] == 21.5
+
+
+async def test_system_target_fan_out_does_not_reload_or_unload_entities(hass) -> None:
+    """System target fan-out should stay on the runtime path."""
+    entry, _ = await _setup_loaded_entry(hass)
+
+    with (
+        patch.object(
+            hass.config_entries,
+            "async_reload",
+            AsyncMock(return_value=True),
+        ) as mock_reload,
+        patch.object(
+            hass.config_entries,
+            "async_unload_platforms",
+            AsyncMock(return_value=True),
+        ) as mock_unload_platforms,
+    ):
+        await hass.services.async_call(
+            "climate",
+            "set_temperature",
+            {
+                ATTR_ENTITY_ID: "climate.multi_zone_heating_system",
+                "temperature": 21.5,
+            },
+            blocking=True,
+        )
+        await hass.async_block_till_done()
+
+    mock_reload.assert_not_awaited()
+    mock_unload_platforms.assert_not_awaited()
+
+    system_state = hass.states.get("climate.multi_zone_heating_system")
+    assert system_state is not None
+    assert system_state.state == "heat"
+    assert system_state.attributes["temperature"] == 21.5
+
+    zone_state = hass.states.get("climate.multi_zone_heating_living_room")
+    assert zone_state is not None
+    assert zone_state.state == "heat"
+    assert zone_state.attributes["temperature"] == 21.5
 
 
 async def test_system_climate_clamps_fanned_target_to_zone_frost_floor(hass) -> None:

--- a/tests/components/multi_zone_heating/test_entities.py
+++ b/tests/components/multi_zone_heating/test_entities.py
@@ -39,7 +39,7 @@ def _build_config_entry() -> MockConfigEntry:
                 }
             ],
         },
-        version=1,
+        version=2,
     )
 
 

--- a/tests/components/multi_zone_heating/test_init.py
+++ b/tests/components/multi_zone_heating/test_init.py
@@ -26,6 +26,7 @@ from custom_components.multi_zone_heating.models import (
     ControlType,
     RuntimeData,
 )
+from custom_components.multi_zone_heating.runtime_state import RuntimeStateStore
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
 
@@ -179,8 +180,8 @@ async def test_setup_rejects_legacy_zone_migration_without_usable_target(hass) -
     assert config_entry.data[CONF_ZONES][0][CONF_TARGET_TEMPERATURE] == 20.0
 
 
-async def test_zone_target_updates_persist_when_options_own_zones(hass) -> None:
-    """Runtime target changes should update options when options replace zone config."""
+async def test_zone_target_updates_persist_in_runtime_store_when_options_own_zones(hass) -> None:
+    """Runtime target changes should persist outside options-owned zone config."""
     config_entry = MockConfigEntry(
         domain=DOMAIN,
         title="Multi-Zone Heating",
@@ -225,7 +226,61 @@ async def test_zone_target_updates_persist_when_options_own_zones(hass) -> None:
     )
     await hass.async_block_till_done()
 
-    assert config_entry.options[CONF_ZONES][0][CONF_TARGET_TEMPERATURE] == 21.5
+    assert config_entry.options[CONF_ZONES][0][CONF_TARGET_TEMPERATURE] == 20.0
+    assert config_entry.runtime_data.config.zones[0].target_temperature == 21.5
+    assert await RuntimeStateStore(hass, config_entry.entry_id).async_load() == {
+        "Living Room": {
+            CONF_TARGET_TEMPERATURE: 21.5,
+            CONF_ENABLED: True,
+        }
+    }
+
+
+async def test_setup_restores_runtime_zone_state_before_entities_load(hass) -> None:
+    """Setup should overlay persisted runtime-owned zone state onto runtime config."""
+    config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        title="Multi-Zone Heating",
+        data={
+            CONF_ZONES: [
+                {
+                    CONF_NAME: "Living Room",
+                    CONF_ENABLED: True,
+                    CONF_CONTROL_TYPE: ControlType.CLIMATE,
+                    CONF_TARGET_TEMPERATURE: 20.0,
+                    CONF_SENSOR_ENTITY_IDS: ["sensor.living_room_temperature"],
+                    CONF_CLIMATE_ENTITY_IDS: [],
+                    CONF_LOCAL_GROUPS: [],
+                    CONF_AGGREGATION_MODE: AggregationMode.AVERAGE,
+                    CONF_PRIMARY_SENSOR_ENTITY_ID: None,
+                }
+            ],
+        },
+        version=2,
+        state=ConfigEntryState.NOT_LOADED,
+    )
+    hass.states.async_set("sensor.living_room_temperature", "19.0")
+    hass.states.async_set("switch.boiler", "off")
+    config_entry.add_to_hass(hass)
+
+    await RuntimeStateStore(hass, config_entry.entry_id).async_save_zone_state_map(
+        {
+            "Living Room": {
+                CONF_TARGET_TEMPERATURE: 21.5,
+                CONF_ENABLED: False,
+            }
+        }
+    )
+
+    assert await hass.config_entries.async_setup(config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert config_entry.runtime_data.config.zones[0].target_temperature == 21.5
+    assert config_entry.runtime_data.config.zones[0].enabled is False
+    climate_state = hass.states.get("climate.multi_zone_heating_living_room")
+    assert climate_state is not None
+    assert climate_state.attributes["temperature"] == 21.5
+    assert climate_state.state == "off"
 
 
 async def test_setup_migrates_legacy_climate_target_entities(hass) -> None:

--- a/tests/components/multi_zone_heating/test_init.py
+++ b/tests/components/multi_zone_heating/test_init.py
@@ -87,8 +87,8 @@ async def test_setup_entry_prefers_options_over_data(hass) -> None:
     assert [zone.name for zone in config_entry.runtime_data.config.zones] == ["Living Room"]
 
 
-async def test_options_update_triggers_entry_reload(hass, config_entry) -> None:
-    """Updating entry options should reload the integration immediately."""
+async def test_structural_options_update_triggers_entry_reload(hass, config_entry) -> None:
+    """Structural options updates should stay on the reload path."""
     config_entry.add_to_hass(hass)
 
     with patch.object(


### PR DESCRIPTION
## What changed
- added a concrete fix plan for separating runtime thermostat state from structural config-entry reloads
- clarified reload boundaries in the implementation and design docs
- corrected the usage docs to describe the intended runtime behavior
- added follow-up issue docs for runtime-state persistence and reload-boundary regression coverage

## Why
Adjusting the virtual thermostats currently updates config-entry data and triggers a full integration reload. That unloads the virtual climate entities and causes a temporary `Unavailable` state in the UI. These docs changes capture the intended fix direction before implementation work starts.

## Impact
- defines which changes should still reload the integration
- defines which runtime thermostat actions must not reload it
- creates issue-ready work items for the implementation and regression coverage

## Validation
- reviewed the current coordinator, climate entities, and config-entry reload flow
- updated docs only; no code or tests changed in this PR

Closes #36
Closes #37