### PR TITLE
[codex] Add door/window detection configuration, runtime inhibition, and diagnostics

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Version `0.3.1` is the current release. It supports UI-based setup, climate- and
 - A shared main relay that follows aggregate demand and may be backed by a `switch` or `input_boolean`
 - Zone control via `climate`, `switch`, or `number` actuators
 - Integration-owned zone targets
+- Optional per-zone door/window/opening detector inhibition
 - Temperature aggregation using `average`, `minimum`, or `primary` sensor selection
 - Optional relay timing protections:
   - minimum relay on time

--- a/custom_components/multi_zone_heating/climate.py
+++ b/custom_components/multi_zone_heating/climate.py
@@ -268,6 +268,12 @@ class MultiZoneHeatingZoneClimate(MultiZoneHeatingClimateBase):
             "aggregation_mode": zone.aggregation_mode.value,
             "enabled": zone.enabled,
             "demand": evaluation.demand,
+            "opening_inhibited": evaluation.opening_inhibited,
+            "open_detector_entity_ids": evaluation.open_detector_entity_ids,
+            "open_detector_open_entity_ids": evaluation.open_detector_open_entity_ids,
+            "open_detector_unavailable_entity_ids": (
+                evaluation.open_detector_unavailable_entity_ids
+            ),
         }
         if zone.primary_sensor_entity_id is not None:
             attributes["primary_sensor_entity_id"] = zone.primary_sensor_entity_id

--- a/custom_components/multi_zone_heating/climate.py
+++ b/custom_components/multi_zone_heating/climate.py
@@ -209,6 +209,7 @@ class MultiZoneHeatingZoneClimate(MultiZoneHeatingClimateBase):
             zone is None
             or evaluation is None
             or not zone.enabled
+            or evaluation.opening_inhibited
             or data.global_force_off
         ):
             return HVACAction.OFF

--- a/custom_components/multi_zone_heating/config_flow.py
+++ b/custom_components/multi_zone_heating/config_flow.py
@@ -9,6 +9,7 @@ import voluptuous as vol
 from homeassistant.config_entries import ConfigEntry, ConfigFlow, OptionsFlowWithConfigEntry
 from homeassistant.const import CONF_NAME
 from homeassistant.core import callback
+from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers import selector
 
 from .const import DEFAULT_TITLE, CONFIG_ENTRY_VERSION, DOMAIN
@@ -35,6 +36,7 @@ CONF_MISSING_FLOW_TIMEOUT_SECONDS = "missing_flow_timeout_seconds"
 CONF_MIN_RELAY_OFF_TIME_SECONDS = "min_relay_off_time_seconds"
 CONF_MIN_RELAY_ON_TIME_SECONDS = "min_relay_on_time_seconds"
 CONF_NUMBER_SEMANTIC_TYPE = "number_semantic_type"
+CONF_OPEN_DETECTOR_ENTITY_IDS = "open_detector_entity_ids"
 CONF_PRIMARY_SENSOR_ENTITY_ID = "primary_sensor_entity_id"
 CONF_RELAY_OFF_DELAY_SECONDS = "relay_off_delay_seconds"
 CONF_SENSOR_ENTITY_IDS = "sensor_entity_ids"
@@ -143,6 +145,9 @@ class _MultiZoneHeatingFlowBase:
                 ),
                 vol.Optional(CONF_FROST_PROTECTION_MIN_TEMP): selector.NumberSelector(
                     selector.NumberSelectorConfig(step=0.5, mode="box")
+                ),
+                vol.Optional(CONF_OPEN_DETECTOR_ENTITY_IDS): selector.EntitySelector(
+                    selector.EntitySelectorConfig(domain=["binary_sensor"], multiple=True)
                 ),
             }
         )
@@ -319,6 +324,16 @@ class _MultiZoneHeatingFlowBase:
         name = str(user_input[CONF_NAME]).strip()
         if not name:
             return {"base": "zone_name_required"}
+        open_detector_entity_ids = _entity_id_list(
+            user_input.get(CONF_OPEN_DETECTOR_ENTITY_IDS)
+        )
+        if open_detector_entity_ids is None:
+            return {"base": "invalid_open_detector_entity"}
+        for entity_id in open_detector_entity_ids:
+            if not cv.valid_entity_id(entity_id) or not entity_id.startswith(
+                "binary_sensor."
+            ):
+                return {"base": "invalid_open_detector_entity"}
 
         return {}
 
@@ -394,6 +409,20 @@ class _MultiZoneHeatingFlowBase:
     def _build_pending_zone(self, user_input: dict[str, object]) -> None:
         """Store the shared zone fields that apply to all control types."""
         zone_frost_protection = user_input.get(CONF_FROST_PROTECTION_MIN_TEMP)
+        existing_zone = None
+        if self._editing_zone_index is not None:
+            existing_zone = self._zones()[self._editing_zone_index]
+        if CONF_OPEN_DETECTOR_ENTITY_IDS in user_input:
+            open_detector_entity_ids = (
+                _entity_id_list(user_input.get(CONF_OPEN_DETECTOR_ENTITY_IDS)) or []
+            )
+        elif existing_zone is not None:
+            open_detector_entity_ids = list(
+                existing_zone.get(CONF_OPEN_DETECTOR_ENTITY_IDS, [])
+            )
+        else:
+            open_detector_entity_ids = []
+
         self._pending_zone = {
             CONF_NAME: str(user_input[CONF_NAME]).strip(),
             CONF_ENABLED: user_input[CONF_ENABLED],
@@ -402,13 +431,13 @@ class _MultiZoneHeatingFlowBase:
                 self._config.get(CONF_FROST_PROTECTION_MIN_TEMP),
                 zone_frost_protection
             ),
+            CONF_OPEN_DETECTOR_ENTITY_IDS: open_detector_entity_ids,
             CONF_FROST_PROTECTION_MIN_TEMP: user_input.get(
                 CONF_FROST_PROTECTION_MIN_TEMP
             ),
         }
 
-        if self._editing_zone_index is not None:
-            existing_zone = self._zones()[self._editing_zone_index]
+        if existing_zone is not None:
             self._pending_zone[CONF_TARGET_TEMPERATURE] = existing_zone.get(
                 CONF_TARGET_TEMPERATURE,
                 initial_zone_target_temperature(
@@ -535,6 +564,7 @@ class _MultiZoneHeatingFlowBase:
             CONF_NAME: zone[CONF_NAME],
             CONF_ENABLED: zone.get(CONF_ENABLED, True),
             CONF_CONTROL_TYPE: zone[CONF_CONTROL_TYPE],
+            CONF_OPEN_DETECTOR_ENTITY_IDS: zone.get(CONF_OPEN_DETECTOR_ENTITY_IDS, []),
             CONF_FROST_PROTECTION_MIN_TEMP: zone.get(CONF_FROST_PROTECTION_MIN_TEMP),
         }
 
@@ -570,6 +600,19 @@ class _MultiZoneHeatingFlowBase:
             CONF_ACTIVE_VALUE: group.get(CONF_ACTIVE_VALUE),
             CONF_INACTIVE_VALUE: group.get(CONF_INACTIVE_VALUE),
         }
+
+
+def _entity_id_list(value: object) -> list[str] | None:
+    """Return a list of entity IDs from selector input."""
+    if value is None:
+        return []
+    if isinstance(value, str):
+        return [value]
+    if isinstance(value, list):
+        if all(isinstance(entity_id, str) for entity_id in value):
+            return value
+        return None
+    return None
 
 
 class MultiZoneHeatingConfigFlow(_MultiZoneHeatingFlowBase, ConfigFlow, domain=DOMAIN):

--- a/custom_components/multi_zone_heating/control_logic.py
+++ b/custom_components/multi_zone_heating/control_logic.py
@@ -157,6 +157,9 @@ def evaluate_zone(
     sensor_values: Mapping[str, float | None],
     *,
     zone_target_temperature: float | None,
+    opening_inhibited: bool = False,
+    open_detector_open_entity_ids: Sequence[str] | None = None,
+    open_detector_unavailable_entity_ids: Sequence[str] | None = None,
     available_actuator_entity_ids: Collection[str] | None = None,
     previous_demand: bool,
     previous_group_demands: Mapping[str, bool] | None = None,
@@ -170,7 +173,10 @@ def evaluate_zone(
         global_frost_protection_min_temp=global_frost_protection_min_temp,
     )
 
-    if not zone.enabled:
+    open_detector_open_entity_ids = list(open_detector_open_entity_ids or [])
+    open_detector_unavailable_entity_ids = list(open_detector_unavailable_entity_ids or [])
+
+    if not zone.enabled or opening_inhibited:
         return ZoneEvaluation(
             name=zone.name,
             control_type=zone.control_type,
@@ -178,6 +184,10 @@ def evaluate_zone(
             target_temperature=zone_target_temperature,
             effective_target_temperature=effective_target_temperature,
             demand=False,
+            opening_inhibited=opening_inhibited,
+            open_detector_entity_ids=list(zone.open_detector_entity_ids),
+            open_detector_open_entity_ids=open_detector_open_entity_ids,
+            open_detector_unavailable_entity_ids=open_detector_unavailable_entity_ids,
         )
 
     if zone.local_groups:
@@ -202,6 +212,10 @@ def evaluate_zone(
             target_temperature=zone_target_temperature,
             effective_target_temperature=effective_target_temperature,
             demand=any(group.demand for group in local_groups),
+            opening_inhibited=opening_inhibited,
+            open_detector_entity_ids=list(zone.open_detector_entity_ids),
+            open_detector_open_entity_ids=open_detector_open_entity_ids,
+            open_detector_unavailable_entity_ids=open_detector_unavailable_entity_ids,
             local_groups=local_groups,
         )
 
@@ -227,6 +241,10 @@ def evaluate_zone(
         target_temperature=zone_target_temperature,
         effective_target_temperature=effective_target_temperature,
         demand=demand,
+        opening_inhibited=opening_inhibited,
+        open_detector_entity_ids=list(zone.open_detector_entity_ids),
+        open_detector_open_entity_ids=open_detector_open_entity_ids,
+        open_detector_unavailable_entity_ids=open_detector_unavailable_entity_ids,
         available_sensor_entity_ids=[
             entity_id
             for entity_id, _ in _available_temperatures(sensor_values, zone.sensor_entity_ids)

--- a/custom_components/multi_zone_heating/coordinator.py
+++ b/custom_components/multi_zone_heating/coordinator.py
@@ -75,6 +75,7 @@ def _zone_from_dict(data: Mapping[str, Any]) -> ZoneConfig:
         target_temperature=target_temperature if target_temperature is not None else 20.0,
         sensor_entity_ids=list(data.get("sensor_entity_ids", [])),
         climate_entity_ids=list(data.get("climate_entity_ids", [])),
+        open_detector_entity_ids=list(data.get("open_detector_entity_ids", [])),
         climate_off_fallback_temperature=_as_float(
             data.get("climate_off_fallback_temperature")
         ),

--- a/custom_components/multi_zone_heating/coordinator.py
+++ b/custom_components/multi_zone_heating/coordinator.py
@@ -189,7 +189,7 @@ class MultiZoneHeatingCoordinator(DataUpdateCoordinator[RuntimeSnapshot]):
     @callback
     def _async_handle_relevant_state_change(self, _event: Any) -> None:
         """Reevaluate the system when a relevant entity changes."""
-        self.hass.async_create_task(self.async_request_refresh())
+        self.hass.async_create_task(self.async_refresh())
 
     async def async_set_zone_enabled(self, zone_name: str, enabled: bool) -> None:
         """Enable or disable one configured zone."""

--- a/custom_components/multi_zone_heating/coordinator.py
+++ b/custom_components/multi_zone_heating/coordinator.py
@@ -322,10 +322,23 @@ class MultiZoneHeatingCoordinator(DataUpdateCoordinator[RuntimeSnapshot]):
 
         zone_evaluations = []
         for zone in self.config.zones:
+            open_detector_open_entity_ids = [
+                entity_id
+                for entity_id in zone.open_detector_entity_ids
+                if snapshot.open_detector_states.get(entity_id) is True
+            ]
+            open_detector_unavailable_entity_ids = [
+                entity_id
+                for entity_id in zone.open_detector_entity_ids
+                if snapshot.open_detector_states.get(entity_id) is None
+            ]
             evaluation = evaluate_zone(
                 zone,
                 snapshot.sensor_values,
                 zone_target_temperature=snapshot.target_temperatures.get(zone.name),
+                opening_inhibited=bool(open_detector_open_entity_ids),
+                open_detector_open_entity_ids=open_detector_open_entity_ids,
+                open_detector_unavailable_entity_ids=open_detector_unavailable_entity_ids,
                 available_actuator_entity_ids=snapshot.actuator_available_entity_ids,
                 previous_demand=self._last_zone_demands.get(zone.name, False),
                 previous_group_demands=self._last_group_demands.get(zone.name),
@@ -410,6 +423,15 @@ class MultiZoneHeatingCoordinator(DataUpdateCoordinator[RuntimeSnapshot]):
                 else:
                     unavailable_entity_ids.add(climate_entity_id)
 
+            for detector_entity_id in zone.open_detector_entity_ids:
+                detector_open = self._read_toggle_state(detector_entity_id)
+                snapshot.open_detector_states[detector_entity_id] = detector_open
+                if detector_open is True:
+                    snapshot.open_detector_open_entity_ids.append(detector_entity_id)
+                elif detector_open is None:
+                    snapshot.open_detector_unavailable_entity_ids.append(detector_entity_id)
+                    unavailable_entity_ids.add(detector_entity_id)
+
             for group in zone.local_groups:
                 for sensor_entity_id in group.sensor_entity_ids:
                     sensor_value = self._read_numeric_state(sensor_entity_id)
@@ -441,6 +463,12 @@ class MultiZoneHeatingCoordinator(DataUpdateCoordinator[RuntimeSnapshot]):
                 unavailable_entity_ids.add(self.config.flow_sensor_entity_id)
 
         snapshot.actuator_available_entity_ids = sorted(actuator_available_entity_ids)
+        snapshot.open_detector_open_entity_ids = sorted(
+            set(snapshot.open_detector_open_entity_ids)
+        )
+        snapshot.open_detector_unavailable_entity_ids = sorted(
+            set(snapshot.open_detector_unavailable_entity_ids)
+        )
         snapshot.unavailable_entity_ids = sorted(unavailable_entity_ids)
         return snapshot
 
@@ -476,7 +504,7 @@ class MultiZoneHeatingCoordinator(DataUpdateCoordinator[RuntimeSnapshot]):
                 await self._async_dispatch_climate_zone(zone, evaluation, force_off=force_off)
                 continue
 
-            if force_off or not zone.enabled:
+            if force_off or not zone.enabled or evaluation.opening_inhibited:
                 for group_config in zone.local_groups:
                     if group_config.control_type is ControlType.SWITCH:
                         await self._async_dispatch_switch_group(group_config, False)
@@ -508,7 +536,7 @@ class MultiZoneHeatingCoordinator(DataUpdateCoordinator[RuntimeSnapshot]):
         force_off: bool,
     ) -> None:
         """Synchronize climate actuators with the effective target temperature."""
-        zone_master_active = zone.enabled and not force_off
+        zone_master_active = zone.enabled and not force_off and not evaluation.opening_inhibited
 
         for entity_id in zone.climate_entity_ids:
             if not self._entity_is_available(entity_id):
@@ -946,6 +974,7 @@ def _iter_relevant_entity_ids(config: IntegrationConfig) -> Iterable[str]:
     for zone in config.zones:
         yield from zone.sensor_entity_ids
         yield from zone.climate_entity_ids
+        yield from zone.open_detector_entity_ids
         for group in zone.local_groups:
             yield from group.sensor_entity_ids
             yield from group.actuator_entity_ids

--- a/custom_components/multi_zone_heating/diagnostics.py
+++ b/custom_components/multi_zone_heating/diagnostics.py
@@ -134,7 +134,7 @@ def _zone_diagnostics(
         "hvac_mode": "heat" if zone.enabled else "off",
         "hvac_action": (
             "off"
-            if not zone.enabled or global_force_off
+            if not zone.enabled or global_force_off or evaluation.opening_inhibited
             else "heating" if evaluation.demand else "idle"
         ),
         "control_type": zone.control_type.value,
@@ -142,6 +142,12 @@ def _zone_diagnostics(
         "enabled": zone.enabled,
         "demand": evaluation.demand,
         "global_force_off": global_force_off,
+        "opening_inhibited": evaluation.opening_inhibited,
+        "open_detector_entity_ids": evaluation.open_detector_entity_ids,
+        "open_detector_open_entity_ids": evaluation.open_detector_open_entity_ids,
+        "open_detector_unavailable_entity_ids": (
+            evaluation.open_detector_unavailable_entity_ids
+        ),
         "target_temperature": evaluation.target_temperature,
         "effective_target_temperature": evaluation.effective_target_temperature,
         "current_temperature": evaluation.current_temperature,

--- a/custom_components/multi_zone_heating/models.py
+++ b/custom_components/multi_zone_heating/models.py
@@ -58,6 +58,7 @@ class ZoneConfig:
     target_temperature: float
     sensor_entity_ids: list[str] = field(default_factory=list)
     climate_entity_ids: list[str] = field(default_factory=list)
+    open_detector_entity_ids: list[str] = field(default_factory=list)
     climate_off_fallback_temperature: float | None = None
     local_groups: list[LocalControlGroup] = field(default_factory=list)
     aggregation_mode: AggregationMode = AggregationMode.AVERAGE

--- a/custom_components/multi_zone_heating/models.py
+++ b/custom_components/multi_zone_heating/models.py
@@ -122,6 +122,10 @@ class ZoneEvaluation:
     target_temperature: float | None
     effective_target_temperature: float | None
     demand: bool
+    opening_inhibited: bool = False
+    open_detector_entity_ids: list[str] = field(default_factory=list)
+    open_detector_open_entity_ids: list[str] = field(default_factory=list)
+    open_detector_unavailable_entity_ids: list[str] = field(default_factory=list)
     available_sensor_entity_ids: list[str] = field(default_factory=list)
     available_actuator_entity_ids: list[str] = field(default_factory=list)
     local_groups: list[LocalControlGroupEvaluation] = field(default_factory=list)
@@ -170,6 +174,9 @@ class RuntimeSnapshot:
     flow_detected: bool = False
     missing_flow_warning: bool = False
     missing_flow_warning_since: datetime | None = None
+    open_detector_states: dict[str, bool | None] = field(default_factory=dict)
+    open_detector_open_entity_ids: list[str] = field(default_factory=list)
+    open_detector_unavailable_entity_ids: list[str] = field(default_factory=list)
     actuator_available_entity_ids: list[str] = field(default_factory=list)
     unavailable_entity_ids: list[str] = field(default_factory=list)
     zone_evaluations: list[ZoneEvaluation] = field(default_factory=list)

--- a/custom_components/multi_zone_heating/strings.json
+++ b/custom_components/multi_zone_heating/strings.json
@@ -9,6 +9,7 @@
       "group_name_required": "Each local control group needs a name.",
       "group_requires_actuators": "Each local control group needs at least one actuator.",
       "group_requires_sensors": "Each local control group needs at least one temperature sensor.",
+      "invalid_open_detector_entity": "Open detector entities must be binary sensors.",
       "number_values_required": "Number control groups need active and inactive values.",
       "primary_sensor_not_in_sensors": "The primary sensor must be one of the selected sensors.",
       "primary_sensor_required": "Select a primary sensor when using primary aggregation.",
@@ -40,7 +41,8 @@
           "control_type": "Control type",
           "enabled": "Enabled",
           "frost_protection_min_temp": "Zone frost minimum",
-          "name": "Zone name"
+          "name": "Zone name",
+          "open_detector_entity_ids": "Door, window, or opening detectors"
         }
       },
       "climate_zone": {
@@ -90,6 +92,7 @@
       "group_name_required": "Each local control group needs a name.",
       "group_requires_actuators": "Each local control group needs at least one actuator.",
       "group_requires_sensors": "Each local control group needs at least one temperature sensor.",
+      "invalid_open_detector_entity": "Open detector entities must be binary sensors.",
       "number_values_required": "Number control groups need active and inactive values.",
       "primary_sensor_not_in_sensors": "The primary sensor must be one of the selected sensors.",
       "primary_sensor_required": "Select a primary sensor when using primary aggregation.",
@@ -142,7 +145,8 @@
           "control_type": "Control type",
           "enabled": "Enabled",
           "frost_protection_min_temp": "Zone frost minimum",
-          "name": "Zone name"
+          "name": "Zone name",
+          "open_detector_entity_ids": "Door, window, or opening detectors"
         }
       },
       "climate_zone": {

--- a/custom_components/multi_zone_heating/translations/en.json
+++ b/custom_components/multi_zone_heating/translations/en.json
@@ -9,6 +9,7 @@
       "group_name_required": "Each local control group needs a name.",
       "group_requires_actuators": "Each local control group needs at least one actuator.",
       "group_requires_sensors": "Each local control group needs at least one temperature sensor.",
+      "invalid_open_detector_entity": "Open detector entities must be binary sensors.",
       "number_values_required": "Number control groups need active and inactive values.",
       "primary_sensor_not_in_sensors": "The primary sensor must be one of the selected sensors.",
       "primary_sensor_required": "Select a primary sensor when using primary aggregation.",
@@ -40,7 +41,8 @@
           "control_type": "Control type",
           "enabled": "Enabled",
           "frost_protection_min_temp": "Zone frost minimum",
-          "name": "Zone name"
+          "name": "Zone name",
+          "open_detector_entity_ids": "Door, window, or opening detectors"
         }
       },
       "climate_zone": {
@@ -90,6 +92,7 @@
       "group_name_required": "Each local control group needs a name.",
       "group_requires_actuators": "Each local control group needs at least one actuator.",
       "group_requires_sensors": "Each local control group needs at least one temperature sensor.",
+      "invalid_open_detector_entity": "Open detector entities must be binary sensors.",
       "number_values_required": "Number control groups need active and inactive values.",
       "primary_sensor_not_in_sensors": "The primary sensor must be one of the selected sensors.",
       "primary_sensor_required": "Select a primary sensor when using primary aggregation.",
@@ -142,7 +145,8 @@
           "control_type": "Control type",
           "enabled": "Enabled",
           "frost_protection_min_temp": "Zone frost minimum",
-          "name": "Zone name"
+          "name": "Zone name",
+          "open_detector_entity_ids": "Door, window, or opening detectors"
         }
       },
       "climate_zone": {

--- a/docs/implementation-plan.md
+++ b/docs/implementation-plan.md
@@ -28,6 +28,7 @@ Version 1 includes:
 - Relay minimum on and off times
 - Relay off-delay and flow-aware shutdown
 - Per-zone enable or disable
+- Per-zone open door/window detection from configured binary sensors
 - Global force-off
 - Global and per-zone frost protection minimums
 - Zone and system demand entities
@@ -62,7 +63,10 @@ Recommended order:
 5. Update slave actuator dispatch for `climate`, `switch`, and `number`
 6. Add relay, flow, and diagnostics behavior
 7. Add top-level climate behavior aligned with the new model
-8. Finish options flow, diagnostics polish, and tests
+8. Add per-zone open door/window sensor configuration and runtime inhibition
+9. Finish options flow, diagnostics polish, and tests
+
+Step 8 is not a standalone milestone. It maps across schema work, pure decision logic, coordinator subscriptions, actuator dispatch, diagnostics, and tests in Milestones 1, 2, 4, 6, and 7.
 
 ## Runtime Persistence Fix Plan
 
@@ -101,18 +105,20 @@ Related stories:
 
 - US-001
 - US-002
+- US-027
 - US-024
 
 ### Milestone 2: Core Decision Engine
 
 Goal:
-Implement pure logic for temperature aggregation, demand state transitions, frost protection, and relay timing using integration-owned zone targets.
+Implement pure logic for temperature aggregation, demand state transitions, open door/window inhibition, frost protection, and relay timing using integration-owned zone targets.
 
 Deliverables:
 
 - Updated `models.py`
 - Updated `control_logic.py`
 - Unit tests for aggregation and hysteresis
+- Unit tests for open door/window inhibition
 - Unit tests that validate zone climate `current_temperature` behavior
 - Unit tests for relay timing rules
 
@@ -123,6 +129,7 @@ Related stories:
 - US-007
 - US-008
 - US-009
+- US-027
 - US-014
 - US-015
 - US-022
@@ -155,6 +162,7 @@ Deliverables:
 
 - Updated `coordinator.py`
 - Entity state collection and validation
+- Door/window sensor state collection and validation
 - Owned target reads from zone climate state only
 - Scheduled reevaluation support for relay timing
 - Command dispatch helpers
@@ -167,6 +175,7 @@ Related stories:
 - US-014
 - US-015
 - US-016
+- US-027
 
 ### Milestone 5: Zone Control Types
 
@@ -194,7 +203,7 @@ Related stories:
 ### Milestone 6: Relay, Overrides, And UX
 
 Goal:
-Make whole-system operation reliable and understandable with the new target ownership model.
+Make whole-system operation reliable and understandable with the new target ownership model, including automatic per-zone inhibition when configured openings are open.
 
 Deliverables:
 
@@ -202,6 +211,7 @@ Deliverables:
 - Numeric flow threshold support
 - Demand-without-flow warning handling
 - Per-zone enable or disable
+- Per-zone door/window sensor selection and automatic zone inhibition
 - Zone climate HVAC mode aligned with zone enable or disable state
 - Global force-off behavior
 - Top-level climate semantics aligned with zone-owned targets
@@ -213,6 +223,7 @@ Related stories:
 - US-018
 - US-019
 - US-021
+- US-027
 
 ### Milestone 7: Diagnostics And Quality
 
@@ -231,6 +242,7 @@ Related stories:
 - US-019
 - US-025
 - US-026
+- US-027
 
 ## Technical Design Decisions
 
@@ -246,8 +258,10 @@ Related stories:
 
 - Reload the entry when structural configuration changes
 - Structural changes include zone additions or removals, zone renames, control-type changes, sensor or actuator membership changes, local-group edits, relay or flow entity changes, and global timing or safety settings changed through the options flow
+- Door/window sensor membership is structural per-zone configuration and changes through config or options flow may reload the entry
 - Do not reload the entry for runtime thermostat actions
 - Runtime actions include zone target changes, zone HVAC mode changes that map to enable or disable, system climate target fan-out, and global force-off toggles
+- Runtime door/window sensor state changes must reevaluate zones in place without updating config entries or unloading platforms
 - Runtime actions must update entity state in place and persist without unloading platforms
 
 ### Zone Climate Ownership
@@ -258,6 +272,21 @@ Related stories:
 - The coordinator must not read target temperature from slave entities
 - The zone climate `hvac_mode` is the canonical enabled or disabled state for the zone
 - Zone target and enabled-state writes must not go through config-entry reload paths
+
+### Door/Window Detection
+
+- Each zone may configure zero or more open-state detector entities
+- Detector entities are selected from Home Assistant `binary_sensor` entities, including sensors with door, window, or opening device classes
+- A configured detector is considered open when its state is `on`
+- A zone is effectively disabled while one or more configured detector entities in that zone are open
+- Open-detector inhibition is runtime state and must not overwrite the persisted manual zone enabled state
+- Closing the last open detector automatically removes the inhibition
+- After inhibition clears, the zone resumes normal control only if it is manually enabled and global force-off is inactive
+- While inhibited, the zone must not generate heat demand and downstream actuators follow the same safe inactive behavior used for an effective zone disable
+- System demand and relay decisions must ignore inhibited zone demand
+- Diagnostics should expose configured detector entities, currently open detector entities, unavailable detector entities, and whether the zone is inhibited by openings
+- Unavailable detector entities do not count as open in version 1, but they must be visible in diagnostics; persistent notifications or repair flows are future work
+- Open-detector inhibition is immediate in version 1; debounce, grace periods, and configurable open-delay behavior are future work
 
 ### Zone Climate Temperature Presentation
 

--- a/docs/installation-and-usage.md
+++ b/docs/installation-and-usage.md
@@ -14,6 +14,7 @@ In version `0.3.1`, it can:
 - drive one or more switch actuators for a switch-based zone
 - drive one or more number actuators for a number-based zone
 - expose system-level control entities for master target fan-out and force-off behavior
+- inhibit a configured zone while selected door, window, or opening sensors are open
 - expose diagnostics for demand, relay state, and missing-flow warnings
 
 ## Before You Start
@@ -27,6 +28,7 @@ You should already have:
 Optional but supported:
 
 - a flow sensor entity
+- binary sensor entities for doors, windows, or other openings you want to use for zone inhibition
 
 ## Installation
 
@@ -102,6 +104,21 @@ Supported zone control types in `0.3.1`:
 
 New zones start at `20.0` degrees Celsius. If the global or zone frost minimum is higher than `20.0`, that higher value becomes the initial zone target instead.
 
+### Door And Window Detection
+
+Each zone can optionally list one or more `binary_sensor` entities as door, window, or opening detectors.
+
+Behavior:
+
+- a detector is considered open when its state is `on`
+- if any configured detector in a zone is open, that zone is temporarily inhibited
+- an inhibited zone stays manually enabled, but it does not contribute heat demand
+- climate, switch, and number actuators follow the same inactive behavior used when the zone is effectively off
+- when the final open detector closes, the zone resumes normal control if the zone is still manually enabled and global force-off is inactive
+- unavailable or unknown detectors do not inhibit heating in this version
+
+Diagnostics show the configured detector entity IDs, currently open detector entity IDs, unavailable detector entity IDs, and whether each zone is currently inhibited by an opening. Detector state changes are runtime reevaluations; changing detector membership in the options flow is structural and may reload the entry.
+
 ### Temperature Aggregation
 
 Where multiple sensors are configured, the integration supports:
@@ -132,6 +149,7 @@ Behavior:
 - slave climate entities follow the virtual zone master for `heat` or `off`
 - when demand stops, the zone becomes idle but slave climates do not switch `off` just because demand cleared
 - when the zone is disabled, or global force-off is active, the integration turns the climate entity `off` if supported
+- when a configured door/window detector is open, the same inactive climate behavior applies without changing the manual zone enabled state
 - if `off` is not supported, it can instead write the configured fallback temperature when the zone is disabled or globally forced off
 
 ### Switch Zone
@@ -150,6 +168,7 @@ Behavior:
 
 - if the local group demands heat, its switches are turned on
 - if it does not demand heat, its switches are turned off
+- if a configured door/window detector is open for the zone, all group switches are turned off
 
 ### Number Zone
 
@@ -172,6 +191,7 @@ Behavior:
 
 - when the group demands heat, the integration writes the active value
 - when the group stops demanding heat, it writes the inactive value
+- if a configured door/window detector is open for the zone, the integration writes the inactive value
 
 ## Recommended Setup Flow
 
@@ -208,6 +228,13 @@ Attributes include:
 - `zones_calling_for_heat`
 - `zone_target_temperatures`
 - `global_force_off`
+
+Zone climate attributes also include:
+
+- `opening_inhibited`
+- `open_detector_entity_ids`
+- `open_detector_open_entity_ids`
+- `open_detector_unavailable_entity_ids`
 
 ### Binary Sensors
 

--- a/docs/issues/ISSUE-020-door-window-detector-config.md
+++ b/docs/issues/ISSUE-020-door-window-detector-config.md
@@ -1,0 +1,45 @@
+# ISSUE-020 Door/Window Detector Configuration
+
+## Goal
+
+Add per-zone configuration for open door/window detection through the Home Assistant UI.
+
+## Scope
+
+- Extend the zone config model with optional open-detector entity IDs
+- Update config flow zone creation to select open-detector entities
+- Update options flow zone editing to add, remove, or change open-detector entities
+- Use Home Assistant entity selectors for `binary_sensor` entities
+- Prefer UI filtering or explanatory labels for door, window, and opening device classes where supported
+- Validate that configured detector entities are binary sensors
+- Keep detector membership as structural config-entry data
+- Update translations for all new form fields and validation messages
+
+## Why
+
+Users need to select the sensors that indicate whether a zone is open to the outside before runtime logic can safely pause heating in that zone.
+
+## Related Stories
+
+- US-002
+- US-026
+- US-027
+
+## Acceptance Criteria
+
+- A zone can be saved with zero or more open-detector entities
+- Config flow and options flow both expose the detector selection
+- Door/window detector selections survive reload and restart as part of structural zone configuration
+- Invalid detector entity IDs are rejected or reported clearly
+- Changing detector membership through the options flow follows normal structural reload behavior
+- New strings are present in both `strings.json` and `translations/en.json`
+
+## Dependencies
+
+- ISSUE-002
+- ISSUE-008
+
+## Out Of Scope
+
+- Runtime demand inhibition
+- Diagnostics beyond config validation errors

--- a/docs/issues/ISSUE-021-door-window-runtime-inhibition.md
+++ b/docs/issues/ISSUE-021-door-window-runtime-inhibition.md
@@ -1,0 +1,54 @@
+# ISSUE-021 Door/Window Runtime Inhibition
+
+## Goal
+
+Disable zone heating automatically while one or more configured door/window detectors in that zone are open.
+
+## Scope
+
+- Subscribe to configured open-detector entity state changes
+- Include detector states in the coordinator runtime snapshot
+- Treat a configured detector as open when its `binary_sensor` state is `on`
+- Compute per-zone opening inhibition before demand contributes to system demand
+- Suppress zone demand while any configured detector in the zone is open
+- Dispatch climate, switch, and number actuators using the same inactive behavior used for an effective zone disable
+- Remove the inhibition automatically when the last open detector closes
+- Preserve the persisted manual zone enabled state while automatic inhibition is active
+- Keep runtime detector state changes away from config-entry update and reload paths
+
+## Why
+
+Heating an open room wastes energy. The runtime behavior needs to pause only the affected zone and resume it automatically without changing the user's manual enable or disable preference.
+
+## Related Stories
+
+- US-014
+- US-017
+- US-027
+
+## Acceptance Criteria
+
+- Opening any configured detector disables heat demand for only that detector's zone
+- Opening multiple detectors keeps the zone inhibited until all configured open detectors are closed
+- Closing the last open detector resumes normal control when the zone is manually enabled and global force-off is inactive
+- A manually disabled zone remains disabled after all detectors close
+- Inhibited zones do not contribute to system demand or relay-on decisions
+- Climate actuators are set to `off` or fallback target while inhibited, matching zone-disable behavior
+- Switch actuators turn off while inhibited
+- Number actuators receive inactive values while inhibited
+- Detector state changes reevaluate the coordinator without unloading entities or updating config entries
+- Unavailable detector entities do not count as open
+
+## Dependencies
+
+- ISSUE-003
+- ISSUE-004
+- ISSUE-005
+- ISSUE-016
+- ISSUE-020
+
+## Out Of Scope
+
+- Config flow and options flow UI
+- Rich repair flows for unavailable detectors
+- Debounce, grace periods, or configurable open-delay behavior

--- a/docs/issues/ISSUE-022-door-window-diagnostics-and-tests.md
+++ b/docs/issues/ISSUE-022-door-window-diagnostics-and-tests.md
@@ -1,0 +1,49 @@
+# ISSUE-022 Door/Window Diagnostics And Tests
+
+## Goal
+
+Expose open door/window inhibition clearly and cover the behavior with focused tests.
+
+## Scope
+
+- Add diagnostics for configured detector entities per zone
+- Report currently open detector entities per zone
+- Report unavailable detector entities per zone
+- Report whether a zone is inhibited by an open detector
+- Add unit tests for pure open-detector inhibition decisions
+- Add coordinator tests for detector state subscriptions and reevaluation
+- Add integration tests for climate, switch, and number zone inhibition behavior
+- Add regression coverage that detector state changes do not reload the config entry
+- Add tests for manual-disable preservation while detector inhibition starts and clears
+- Update user-facing documentation where needed for the new behavior
+
+## Why
+
+Automatic zone inhibition changes heating behavior without a direct manual command. Users and maintainers need clear status and regression coverage so the feature is predictable and diagnosable.
+
+## Related Stories
+
+- US-019
+- US-025
+- US-027
+
+## Acceptance Criteria
+
+- Diagnostics identify detector configuration, open detector state, unavailable detector state, and effective zone inhibition
+- Tests cover one detector open, multiple detectors open, all detectors closed, and detector unavailable cases
+- Tests cover that inhibited zones do not contribute to system demand
+- Tests cover that manual zone disable state is preserved when detector inhibition clears
+- Tests cover no config-entry reload for detector state changes
+- Documentation describes how to configure and interpret open door/window detection
+
+## Dependencies
+
+- ISSUE-009
+- ISSUE-020
+- ISSUE-021
+
+## Out Of Scope
+
+- New repair issue flows
+- Persistent notifications for unavailable detector entities
+- Auto-suggesting likely door/window sensors

--- a/docs/user-stories.md
+++ b/docs/user-stories.md
@@ -257,6 +257,27 @@ Acceptance criteria:
 - A disabled zone does not generate demand
 - Disabling a zone updates downstream actuation accordingly
 
+#### US-027 Disable a zone when a door or window is open
+
+As a home owner,
+I want the integration to detect open doors and windows in each zone,
+so that heating is paused automatically while that zone is open to the outside.
+
+This story supersedes the earlier deferred idea to infer open windows from zone disable patterns. Version 1 uses explicitly configured detector entities instead of inference.
+
+Acceptance criteria:
+
+- Each zone can optionally select one or more open-state detector entities through the UI
+- The UI supports Home Assistant `binary_sensor` entities, including door, window, and opening sensors
+- A configured detector is considered open when its state is `on`
+- If one or more configured detectors in a zone are open, that zone is effectively disabled
+- An effectively disabled zone does not generate heat demand
+- While a zone is disabled by an open detector, climate, switch, and number actuators follow the same inactive behavior used for a disabled zone
+- When the last open detector in the zone closes, the automatic disable is removed and the zone resumes normal operation if it is manually enabled
+- Open-detector state changes do not persist or overwrite the user's manual zone enabled state
+- The zone climate, zone enabled surface, diagnostics, or status attributes make it clear when the zone is inhibited because an opening is open
+- Unavailable detector entities do not count as open, but they are reported in diagnostics
+
 #### US-018 Force all heating off globally
 
 As a home owner,
@@ -379,12 +400,6 @@ Acceptance criteria:
 
 ## Later Stories
 
-#### US-027 Detect open windows from zone disable patterns
-
-As a home owner,
-I want the integration to support smarter zone disable behavior,
-so that open-window logic can be added later.
-
 #### US-028 Provide richer fault entities and repair flows
 
 As a home owner,
@@ -418,6 +433,7 @@ The smallest coherent version 1 should include:
 - Demand calculation with global hysteresis
 - Global and per-zone frost protection minimums
 - Per-zone enable or disable
+- Per-zone open door/window detection
 - Global force-off
 - Zone and system demand entities
 - Top-level climate entity

--- a/tests/components/multi_zone_heating/test_config_flow.py
+++ b/tests/components/multi_zone_heating/test_config_flow.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import pytest
+
 from homeassistant import config_entries, data_entry_flow
 from homeassistant.const import CONF_NAME
 
@@ -38,6 +40,7 @@ from custom_components.multi_zone_heating.config_flow import (
     CONF_MIN_RELAY_OFF_TIME_SECONDS,
     CONF_MIN_RELAY_ON_TIME_SECONDS,
     CONF_NUMBER_SEMANTIC_TYPE,
+    CONF_OPEN_DETECTOR_ENTITY_IDS,
     CONF_PRIMARY_SENSOR_ENTITY_ID,
     CONF_RELAY_OFF_DELAY_SECONDS,
     CONF_SENSOR_ENTITY_IDS,
@@ -91,6 +94,7 @@ def _existing_config() -> dict[str, object]:
                 CONF_CONTROL_TYPE: ControlType.SWITCH,
                 CONF_TARGET_TEMPERATURE: DEFAULT_ZONE_TARGET_TEMPERATURE,
                 CONF_FROST_PROTECTION_MIN_TEMP: None,
+                CONF_OPEN_DETECTOR_ENTITY_IDS: [],
                 CONF_SENSOR_ENTITY_IDS: [],
                 CONF_CLIMATE_ENTITY_IDS: [],
                 CONF_LOCAL_GROUPS: [
@@ -174,6 +178,10 @@ async def test_user_flow_creates_entry_for_climate_zone(hass) -> None:
             CONF_ENABLED: True,
             CONF_CONTROL_TYPE: ControlType.CLIMATE,
             CONF_FROST_PROTECTION_MIN_TEMP: 8.0,
+            CONF_OPEN_DETECTOR_ENTITY_IDS: [
+                "binary_sensor.living_room_window",
+                "binary_sensor.living_room_door",
+            ],
         },
     )
 
@@ -218,6 +226,10 @@ async def test_user_flow_creates_entry_for_climate_zone(hass) -> None:
                 CONF_CONTROL_TYPE: ControlType.CLIMATE,
                 CONF_TARGET_TEMPERATURE: 20.0,
                 CONF_FROST_PROTECTION_MIN_TEMP: 8.0,
+                CONF_OPEN_DETECTOR_ENTITY_IDS: [
+                    "binary_sensor.living_room_window",
+                    "binary_sensor.living_room_door",
+                ],
                 CONF_SENSOR_ENTITY_IDS: ["sensor.living_room_temperature"],
                 CONF_CLIMATE_ENTITY_IDS: ["climate.living_room_radiator"],
                 CONF_CLIMATE_OFF_FALLBACK_TEMPERATURE: 7.5,
@@ -295,6 +307,7 @@ async def test_user_flow_creates_entry_for_switch_zone_with_local_group(hass) ->
             CONF_CONTROL_TYPE: ControlType.SWITCH,
             CONF_TARGET_TEMPERATURE: DEFAULT_ZONE_TARGET_TEMPERATURE,
             CONF_FROST_PROTECTION_MIN_TEMP: None,
+            CONF_OPEN_DETECTOR_ENTITY_IDS: [],
             CONF_SENSOR_ENTITY_IDS: [],
             CONF_CLIMATE_ENTITY_IDS: [],
             CONF_LOCAL_GROUPS: [
@@ -532,6 +545,24 @@ async def test_zone_requires_non_empty_name(hass) -> None:
     assert result["errors"] == {"base": "zone_name_required"}
 
 
+async def test_zone_rejects_non_binary_open_detector_entities(hass) -> None:
+    """Open detector selections should be limited to binary sensors."""
+    result = await _start_basic_flow(hass)
+
+    with pytest.raises(data_entry_flow.InvalidData) as exc_info:
+        await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {
+                CONF_NAME: "Living Room",
+                CONF_ENABLED: True,
+                CONF_CONTROL_TYPE: ControlType.CLIMATE,
+                CONF_OPEN_DETECTOR_ENTITY_IDS: ["sensor.living_room_window"],
+            },
+        )
+
+    assert exc_info.value.path == [CONF_OPEN_DETECTOR_ENTITY_IDS, 0]
+
+
 async def test_local_group_requires_non_empty_name(hass) -> None:
     """Local groups should reject blank input."""
     result = await _start_basic_flow(hass)
@@ -655,6 +686,7 @@ async def test_options_flow_updates_globals_zone_and_local_group(hass) -> None:
             CONF_NAME: "Main Bedroom",
             CONF_ENABLED: True,
             CONF_CONTROL_TYPE: ControlType.SWITCH,
+            CONF_OPEN_DETECTOR_ENTITY_IDS: ["binary_sensor.main_bedroom_window"],
             CONF_FROST_PROTECTION_MIN_TEMP: 8.0,
         },
     )
@@ -703,6 +735,9 @@ async def test_options_flow_updates_globals_zone_and_local_group(hass) -> None:
     assert result["data"][CONF_ZONES][0][CONF_NAME] == "Main Bedroom"
     assert result["data"][CONF_ZONES][0][CONF_TARGET_TEMPERATURE] == DEFAULT_ZONE_TARGET_TEMPERATURE
     assert result["data"][CONF_ZONES][0][CONF_FROST_PROTECTION_MIN_TEMP] == 8.0
+    assert result["data"][CONF_ZONES][0][CONF_OPEN_DETECTOR_ENTITY_IDS] == [
+        "binary_sensor.main_bedroom_window"
+    ]
     assert result["data"][CONF_ZONES][0][CONF_LOCAL_GROUPS][0][CONF_NAME] == "Main Radiator"
     assert (
         result["data"][CONF_ZONES][0][CONF_LOCAL_GROUPS][0][CONF_ACTUATOR_ENTITY_IDS]
@@ -877,6 +912,7 @@ async def test_options_flow_can_add_and_remove_zones_and_local_groups(hass) -> N
             CONF_CONTROL_TYPE: ControlType.CLIMATE,
             CONF_TARGET_TEMPERATURE: 20.0,
             CONF_FROST_PROTECTION_MIN_TEMP: 8.0,
+            CONF_OPEN_DETECTOR_ENTITY_IDS: [],
             CONF_SENSOR_ENTITY_IDS: ["sensor.living_room_temperature"],
             CONF_CLIMATE_ENTITY_IDS: ["climate.living_room_radiator"],
             CONF_CLIMATE_OFF_FALLBACK_TEMPERATURE: 7.0,

--- a/tests/components/multi_zone_heating/test_control_logic.py
+++ b/tests/components/multi_zone_heating/test_control_logic.py
@@ -272,6 +272,110 @@ def test_open_detector_inhibited_zone_stays_off_without_disabling_zone() -> None
     assert evaluation.demand is False
 
 
+def test_open_detector_multiple_open_detectors_are_reported() -> None:
+    """All open detectors should be exposed when inhibition is active."""
+    zone = ZoneConfig(
+        name="Study",
+        control_type=ControlType.CLIMATE,
+        target_temperature=20.0,
+        sensor_entity_ids=["sensor.study"],
+        climate_entity_ids=["climate.study"],
+        open_detector_entity_ids=[
+            "binary_sensor.study_window",
+            "binary_sensor.study_door",
+        ],
+        aggregation_mode=AggregationMode.AVERAGE,
+        enabled=True,
+    )
+
+    evaluation = evaluate_zone(
+        zone,
+        {"sensor.study": 16.0},
+        zone_target_temperature=21.0,
+        opening_inhibited=True,
+        open_detector_open_entity_ids=[
+            "binary_sensor.study_window",
+            "binary_sensor.study_door",
+        ],
+        available_actuator_entity_ids=["climate.study"],
+        previous_demand=True,
+        hysteresis=0.3,
+    )
+
+    assert evaluation.opening_inhibited is True
+    assert evaluation.open_detector_entity_ids == [
+        "binary_sensor.study_window",
+        "binary_sensor.study_door",
+    ]
+    assert evaluation.open_detector_open_entity_ids == [
+        "binary_sensor.study_window",
+        "binary_sensor.study_door",
+    ]
+    assert evaluation.demand is False
+    assert aggregate_system_demand([evaluation]) is False
+
+
+def test_open_detector_all_closed_allows_normal_demand() -> None:
+    """Closed detectors should not affect normal zone demand evaluation."""
+    zone = ZoneConfig(
+        name="Study",
+        control_type=ControlType.CLIMATE,
+        target_temperature=20.0,
+        sensor_entity_ids=["sensor.study"],
+        climate_entity_ids=["climate.study"],
+        open_detector_entity_ids=["binary_sensor.study_window"],
+        aggregation_mode=AggregationMode.AVERAGE,
+        enabled=True,
+    )
+
+    evaluation = evaluate_zone(
+        zone,
+        {"sensor.study": 16.0},
+        zone_target_temperature=21.0,
+        opening_inhibited=False,
+        open_detector_open_entity_ids=[],
+        available_actuator_entity_ids=["climate.study"],
+        previous_demand=False,
+        hysteresis=0.3,
+    )
+
+    assert evaluation.opening_inhibited is False
+    assert evaluation.open_detector_open_entity_ids == []
+    assert evaluation.current_temperature == 16.0
+    assert evaluation.demand is True
+
+
+def test_open_detector_unavailable_detector_is_reported_but_not_inhibiting() -> None:
+    """Unavailable detectors should be diagnostic only in version 1."""
+    zone = ZoneConfig(
+        name="Study",
+        control_type=ControlType.CLIMATE,
+        target_temperature=20.0,
+        sensor_entity_ids=["sensor.study"],
+        climate_entity_ids=["climate.study"],
+        open_detector_entity_ids=["binary_sensor.study_window"],
+        aggregation_mode=AggregationMode.AVERAGE,
+        enabled=True,
+    )
+
+    evaluation = evaluate_zone(
+        zone,
+        {"sensor.study": 16.0},
+        zone_target_temperature=21.0,
+        opening_inhibited=False,
+        open_detector_unavailable_entity_ids=["binary_sensor.study_window"],
+        available_actuator_entity_ids=["climate.study"],
+        previous_demand=False,
+        hysteresis=0.3,
+    )
+
+    assert evaluation.opening_inhibited is False
+    assert evaluation.open_detector_unavailable_entity_ids == [
+        "binary_sensor.study_window"
+    ]
+    assert evaluation.demand is True
+
+
 def test_flow_threshold_reached_requires_value_and_threshold() -> None:
     """Flow detection should only become true with both configured inputs."""
     assert flow_threshold_reached(1.6, 1.5) is True

--- a/tests/components/multi_zone_heating/test_control_logic.py
+++ b/tests/components/multi_zone_heating/test_control_logic.py
@@ -241,6 +241,37 @@ def test_disabled_zone_stays_off() -> None:
     assert evaluation.demand is False
 
 
+def test_open_detector_inhibited_zone_stays_off_without_disabling_zone() -> None:
+    """Open detectors should suppress demand without changing manual enabled state."""
+    zone = ZoneConfig(
+        name="Study",
+        control_type=ControlType.CLIMATE,
+        target_temperature=20.0,
+        sensor_entity_ids=["sensor.study"],
+        climate_entity_ids=["climate.study"],
+        open_detector_entity_ids=["binary_sensor.study_window"],
+        aggregation_mode=AggregationMode.AVERAGE,
+        enabled=True,
+    )
+
+    evaluation = evaluate_zone(
+        zone,
+        {"sensor.study": 16.0},
+        zone_target_temperature=21.0,
+        opening_inhibited=True,
+        open_detector_open_entity_ids=["binary_sensor.study_window"],
+        available_actuator_entity_ids=["climate.study"],
+        previous_demand=True,
+        hysteresis=0.3,
+    )
+
+    assert zone.enabled is True
+    assert evaluation.opening_inhibited is True
+    assert evaluation.open_detector_open_entity_ids == ["binary_sensor.study_window"]
+    assert evaluation.current_temperature is None
+    assert evaluation.demand is False
+
+
 def test_flow_threshold_reached_requires_value_and_threshold() -> None:
     """Flow detection should only become true with both configured inputs."""
     assert flow_threshold_reached(1.6, 1.5) is True

--- a/tests/components/multi_zone_heating/test_coordinator.py
+++ b/tests/components/multi_zone_heating/test_coordinator.py
@@ -256,6 +256,189 @@ async def test_coordinator_dispatches_input_boolean_global_relay(hass) -> None:
     await coordinator.async_stop()
 
 
+async def test_coordinator_inhibits_switch_zone_while_open_detector_is_on(hass) -> None:
+    """Open detectors should suppress only their zone until all detectors close."""
+    hass.states.async_set("sensor.living_room_temperature", "19.0")
+    hass.states.async_set("switch.radiator", "off")
+    hass.states.async_set("switch.boiler", "off")
+    hass.states.async_set("binary_sensor.living_room_window", "off")
+
+    calls = _register_recording_switch_services(hass)
+    config = _build_switch_config()
+    config.zones[0].open_detector_entity_ids = ["binary_sensor.living_room_window"]
+
+    coordinator = MultiZoneHeatingCoordinator(hass, config)
+    await coordinator.async_start()
+    await hass.async_block_till_done()
+
+    assert calls == [
+        ("turn_on", {"entity_id": "switch.radiator"}),
+        ("turn_on", {"entity_id": "switch.boiler"}),
+    ]
+
+    calls.clear()
+    hass.states.async_set("switch.radiator", "on")
+    hass.states.async_set("switch.boiler", "on")
+    hass.states.async_set("binary_sensor.living_room_window", "on")
+    await hass.async_block_till_done()
+
+    await coordinator.async_refresh()
+    await hass.async_block_till_done()
+
+    assert coordinator.data is not None
+    assert coordinator.data.system_demand is False
+    assert coordinator.data.open_detector_states == {
+        "binary_sensor.living_room_window": True
+    }
+    assert coordinator.data.open_detector_open_entity_ids == [
+        "binary_sensor.living_room_window"
+    ]
+    assert coordinator.data.zone_evaluations[0].opening_inhibited is True
+    assert coordinator.config.zones[0].enabled is True
+    assert calls == [
+        ("turn_off", {"entity_id": "switch.radiator"}),
+        ("turn_off", {"entity_id": "switch.boiler"}),
+    ]
+
+    calls.clear()
+    hass.states.async_set("switch.radiator", "off")
+    hass.states.async_set("switch.boiler", "off")
+    hass.states.async_set("binary_sensor.living_room_window", "off")
+    await hass.async_block_till_done()
+
+    await coordinator.async_refresh()
+    await hass.async_block_till_done()
+
+    assert coordinator.data is not None
+    assert coordinator.data.system_demand is True
+    assert coordinator.data.zone_evaluations[0].opening_inhibited is False
+    assert calls == [
+        ("turn_on", {"entity_id": "switch.radiator"}),
+        ("turn_on", {"entity_id": "switch.boiler"}),
+    ]
+    await coordinator.async_stop()
+
+
+async def test_coordinator_keeps_zone_inhibited_until_all_open_detectors_close(hass) -> None:
+    """Multiple detectors should inhibit the zone until the last open one closes."""
+    hass.states.async_set("sensor.living_room_temperature", "19.0")
+    hass.states.async_set("switch.radiator", "off")
+    hass.states.async_set("switch.boiler", "off")
+    hass.states.async_set("binary_sensor.living_room_window", "on")
+    hass.states.async_set("binary_sensor.living_room_door", "on")
+
+    calls = _register_recording_switch_services(hass)
+    config = _build_switch_config()
+    config.zones[0].open_detector_entity_ids = [
+        "binary_sensor.living_room_window",
+        "binary_sensor.living_room_door",
+    ]
+
+    coordinator = MultiZoneHeatingCoordinator(hass, config)
+    await coordinator.async_start()
+    await hass.async_block_till_done()
+
+    assert coordinator.data is not None
+    assert coordinator.data.system_demand is False
+    assert coordinator.data.open_detector_open_entity_ids == [
+        "binary_sensor.living_room_door",
+        "binary_sensor.living_room_window",
+    ]
+    assert calls == []
+
+    hass.states.async_set("binary_sensor.living_room_window", "off")
+    await hass.async_block_till_done()
+    await coordinator.async_refresh()
+    await hass.async_block_till_done()
+
+    assert coordinator.data is not None
+    assert coordinator.data.zone_evaluations[0].opening_inhibited is True
+    assert coordinator.data.open_detector_open_entity_ids == [
+        "binary_sensor.living_room_door"
+    ]
+    assert calls == []
+
+    hass.states.async_set("binary_sensor.living_room_door", "off")
+    await hass.async_block_till_done()
+    await coordinator.async_refresh()
+    await hass.async_block_till_done()
+
+    assert coordinator.data is not None
+    assert coordinator.data.zone_evaluations[0].opening_inhibited is False
+    assert coordinator.data.system_demand is True
+    assert calls == [
+        ("turn_on", {"entity_id": "switch.radiator"}),
+        ("turn_on", {"entity_id": "switch.boiler"}),
+    ]
+    await coordinator.async_stop()
+
+
+async def test_coordinator_does_not_reenable_manually_disabled_zone_when_detector_closes(
+    hass,
+) -> None:
+    """Clearing detector inhibition should preserve the manual zone enabled state."""
+    hass.states.async_set("sensor.living_room_temperature", "19.0")
+    hass.states.async_set("switch.radiator", "off")
+    hass.states.async_set("switch.boiler", "off")
+    hass.states.async_set("binary_sensor.living_room_window", "on")
+
+    calls = _register_recording_switch_services(hass)
+    config = _build_switch_config()
+    config.zones[0].enabled = False
+    config.zones[0].open_detector_entity_ids = ["binary_sensor.living_room_window"]
+
+    coordinator = MultiZoneHeatingCoordinator(hass, config)
+    await coordinator.async_start()
+    await hass.async_block_till_done()
+
+    assert coordinator.data is not None
+    assert coordinator.data.zone_evaluations[0].opening_inhibited is True
+    assert coordinator.config.zones[0].enabled is False
+    assert calls == []
+
+    hass.states.async_set("binary_sensor.living_room_window", "off")
+    await hass.async_block_till_done()
+    await coordinator.async_refresh()
+    await hass.async_block_till_done()
+
+    assert coordinator.data is not None
+    assert coordinator.data.zone_evaluations[0].opening_inhibited is False
+    assert coordinator.config.zones[0].enabled is False
+    assert coordinator.data.system_demand is False
+    assert calls == []
+    await coordinator.async_stop()
+
+
+async def test_coordinator_does_not_count_unavailable_open_detector_as_open(hass) -> None:
+    """Unavailable detector entities should be visible but should not inhibit heat."""
+    hass.states.async_set("sensor.living_room_temperature", "19.0")
+    hass.states.async_set("switch.radiator", "off")
+    hass.states.async_set("switch.boiler", "off")
+
+    calls = _register_recording_switch_services(hass)
+    config = _build_switch_config()
+    config.zones[0].open_detector_entity_ids = ["binary_sensor.living_room_window"]
+
+    coordinator = MultiZoneHeatingCoordinator(hass, config)
+    await coordinator.async_start()
+    await hass.async_block_till_done()
+
+    assert coordinator.data is not None
+    assert coordinator.data.zone_evaluations[0].opening_inhibited is False
+    assert coordinator.data.open_detector_states == {
+        "binary_sensor.living_room_window": None
+    }
+    assert coordinator.data.open_detector_unavailable_entity_ids == [
+        "binary_sensor.living_room_window"
+    ]
+    assert coordinator.data.system_demand is True
+    assert calls == [
+        ("turn_on", {"entity_id": "switch.radiator"}),
+        ("turn_on", {"entity_id": "switch.boiler"}),
+    ]
+    await coordinator.async_stop()
+
+
 async def test_coordinator_raises_missing_flow_warning_after_timeout(hass, monkeypatch) -> None:
     """Missing-flow warnings should trip on the scheduled timeout boundary."""
     now = datetime(2026, 4, 8, 10, 0, tzinfo=UTC)
@@ -527,6 +710,33 @@ async def test_coordinator_turns_climate_zone_off_when_global_force_off_is_enabl
     await coordinator.async_stop()
 
 
+async def test_coordinator_turns_climate_zone_off_when_open_detector_is_on(hass) -> None:
+    """Open detectors should use the same inactive climate behavior as zone disable."""
+    hass.states.async_set("sensor.living_room_temperature", "19.0")
+    hass.states.async_set("binary_sensor.living_room_window", "on")
+    hass.states.async_set(
+        "climate.radiator_a",
+        "heat",
+        {"temperature": 20.0, "hvac_modes": [HVACMode.HEAT, HVACMode.OFF]},
+    )
+    hass.states.async_set("switch.boiler", "on")
+    _register_recording_switch_services(hass)
+    climate_calls, hvac_mode_calls = _register_recording_climate_services(hass)
+    config = _build_climate_config()
+    config.zones[0].open_detector_entity_ids = ["binary_sensor.living_room_window"]
+
+    coordinator = MultiZoneHeatingCoordinator(hass, config)
+    await coordinator.async_start()
+    await hass.async_block_till_done()
+
+    assert coordinator.data is not None
+    assert coordinator.data.zone_evaluations[0].opening_inhibited is True
+    assert coordinator.config.zones[0].enabled is True
+    assert climate_calls == []
+    assert hvac_mode_calls == [{"entity_id": "climate.radiator_a", ATTR_HVAC_MODE: HVACMode.OFF}]
+    await coordinator.async_stop()
+
+
 async def test_coordinator_retries_climate_off_when_slave_state_does_not_change(hass) -> None:
     """Forced-off climate commands should be retried until the slave state reflects them."""
     hass.states.async_set("sensor.living_room_temperature", "19.0")
@@ -747,6 +957,53 @@ async def test_coordinator_dispatches_number_group_values(hass) -> None:
     await hass.async_block_till_done()
 
     assert number_calls == [{"entity_id": "number.floor_valve", ATTR_VALUE: 100.0}]
+    await coordinator.async_stop()
+
+
+async def test_coordinator_writes_number_group_inactive_value_when_open_detector_is_on(
+    hass,
+) -> None:
+    """Open detectors should write inactive values for number actuators."""
+    hass.states.async_set("sensor.floor_temperature", "19.0")
+    hass.states.async_set("number.floor_valve", "100")
+    hass.states.async_set("switch.boiler", "on")
+    hass.states.async_set("binary_sensor.floor_window", "on")
+    _register_recording_switch_services(hass)
+    number_calls = _register_recording_number_services(hass)
+
+    coordinator = MultiZoneHeatingCoordinator(
+        hass,
+        IntegrationConfig(
+            main_relay_entity_id="switch.boiler",
+            zones=[
+                ZoneConfig(
+                    name="Floor",
+                    control_type=ControlType.NUMBER,
+                    target_temperature=20.0,
+                    open_detector_entity_ids=["binary_sensor.floor_window"],
+                    local_groups=[
+                        LocalControlGroup(
+                            name="Valve",
+                            control_type=ControlType.NUMBER,
+                            actuator_entity_ids=["number.floor_valve"],
+                            sensor_entity_ids=["sensor.floor_temperature"],
+                            aggregation_mode=AggregationMode.AVERAGE,
+                            number_semantic_type=NumberSemanticType.PERCENTAGE,
+                            active_value=100.0,
+                            inactive_value=0.0,
+                        )
+                    ],
+                )
+            ],
+        ),
+    )
+
+    await coordinator.async_start()
+    await hass.async_block_till_done()
+
+    assert coordinator.data is not None
+    assert coordinator.data.zone_evaluations[0].opening_inhibited is True
+    assert number_calls == [{"entity_id": "number.floor_valve", ATTR_VALUE: 0.0}]
     await coordinator.async_stop()
 
 

--- a/tests/components/multi_zone_heating/test_coordinator.py
+++ b/tests/components/multi_zone_heating/test_coordinator.py
@@ -912,6 +912,7 @@ def test_integration_config_from_dict_builds_typed_models() -> None:
                     "target_temperature": 20.0,
                     "sensor_entity_ids": [],
                     "climate_entity_ids": [],
+                    "open_detector_entity_ids": ["binary_sensor.living_room_window"],
                     "climate_off_fallback_temperature": None,
                     "aggregation_mode": AggregationMode.AVERAGE,
                     "primary_sensor_entity_id": None,
@@ -940,6 +941,7 @@ def test_integration_config_from_dict_builds_typed_models() -> None:
     assert config.default_hysteresis == 0.4
     assert config.zones[0].control_type is ControlType.NUMBER
     assert config.zones[0].target_temperature == 20.0
+    assert config.zones[0].open_detector_entity_ids == ["binary_sensor.living_room_window"]
     assert config.zones[0].climate_off_fallback_temperature is None
     assert config.zones[0].local_groups[0].aggregation_mode is AggregationMode.MINIMUM
     assert config.zones[0].local_groups[0].number_semantic_type is NumberSemanticType.PERCENTAGE

--- a/tests/components/multi_zone_heating/test_diagnostics.py
+++ b/tests/components/multi_zone_heating/test_diagnostics.py
@@ -150,3 +150,44 @@ async def test_zone_climate_diagnostics_distinguish_idle_disabled_and_forced_off
     assert zone["hvac_action"] == "off"
     assert zone["demand"] is False
     assert zone["global_force_off"] is True
+
+
+async def test_diagnostics_include_open_detector_state_by_zone(hass) -> None:
+    """Diagnostics should identify configured, open, and unavailable detectors."""
+    hass.states.async_set("sensor.living_room_temperature", "19.0")
+    hass.states.async_set("sensor.system_flow", "0.0")
+    hass.states.async_set("switch.radiator", STATE_OFF)
+    hass.states.async_set("switch.boiler", STATE_OFF)
+    hass.states.async_set("binary_sensor.living_room_window", "on")
+    _register_recording_switch_services(hass)
+
+    entry = _build_config_entry()
+    entry.data["zones"][0]["open_detector_entity_ids"] = [
+        "binary_sensor.living_room_window",
+        "binary_sensor.living_room_door",
+    ]
+    entry.add_to_hass(hass)
+
+    assert await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    diagnostics = await async_get_config_entry_diagnostics(hass, entry)
+    zone = diagnostics["runtime"]["zone_climates"][0]
+
+    assert zone["open_detector_entity_ids"] == [
+        "binary_sensor.living_room_window",
+        "binary_sensor.living_room_door",
+    ]
+    assert zone["open_detector_open_entity_ids"] == [
+        "binary_sensor.living_room_window"
+    ]
+    assert zone["open_detector_unavailable_entity_ids"] == [
+        "binary_sensor.living_room_door"
+    ]
+    assert zone["opening_inhibited"] is True
+    assert zone["hvac_action"] == "off"
+    assert zone["demand"] is False
+    assert diagnostics["runtime"]["snapshot"]["open_detector_states"] == {
+        "binary_sensor.living_room_window": True,
+        "binary_sensor.living_room_door": None,
+    }

--- a/tests/components/multi_zone_heating/test_entities.py
+++ b/tests/components/multi_zone_heating/test_entities.py
@@ -12,7 +12,10 @@ from custom_components.multi_zone_heating.const import DOMAIN
 from custom_components.multi_zone_heating.runtime_state import RuntimeStateStore
 
 
-def _build_config_entry() -> MockConfigEntry:
+def _build_config_entry(
+    *,
+    open_detector_entity_ids: list[str] | None = None,
+) -> MockConfigEntry:
     """Create a config entry with one switch-controlled zone."""
     return MockConfigEntry(
         domain=DOMAIN,
@@ -36,6 +39,7 @@ def _build_config_entry() -> MockConfigEntry:
                             "aggregation_mode": "average",
                         }
                     ],
+                    "open_detector_entity_ids": open_detector_entity_ids or [],
                 }
             ],
         },
@@ -722,3 +726,56 @@ async def test_zone_climate_keeps_heat_mode_but_reports_off_action_during_global
     assert climate_state.state == "heat"
     assert climate_state.attributes["hvac_action"] == "off"
     assert switch_state.state == STATE_ON
+
+
+async def test_detector_state_change_inhibits_zone_without_reloading_entry(hass) -> None:
+    """Detector state changes should be runtime reevaluations, not entry reloads."""
+    hass.states.async_set("sensor.living_room_temperature", "19.0")
+    hass.states.async_set("switch.radiator", STATE_OFF)
+    hass.states.async_set("switch.boiler", STATE_OFF)
+    hass.states.async_set("binary_sensor.living_room_window", STATE_OFF)
+    await hass.async_block_till_done()
+    _register_recording_switch_services(hass)
+
+    entry = _build_config_entry(
+        open_detector_entity_ids=["binary_sensor.living_room_window"]
+    )
+    entry.add_to_hass(hass)
+    assert await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    with (
+        patch.object(
+            hass.config_entries,
+            "async_reload",
+            AsyncMock(return_value=True),
+        ) as mock_reload,
+        patch.object(
+            hass.config_entries,
+            "async_unload_platforms",
+            AsyncMock(return_value=True),
+        ) as mock_unload_platforms,
+    ):
+        hass.states.async_set("binary_sensor.living_room_window", STATE_ON)
+        await hass.async_block_till_done(wait_background_tasks=True)
+
+    mock_reload.assert_not_awaited()
+    mock_unload_platforms.assert_not_awaited()
+
+    assert (
+        entry.runtime_data.coordinator.data.zone_evaluations[0].opening_inhibited
+        is True
+    )
+
+    zone_climate_state = hass.states.get("climate.multi_zone_heating_living_room")
+    zone_demand_state = hass.states.get("binary_sensor.multi_zone_heating_living_room_demand")
+    assert zone_climate_state is not None
+    assert zone_climate_state.state == "heat"
+    assert zone_climate_state.attributes["hvac_action"] == "off"
+    assert zone_climate_state.attributes["opening_inhibited"] is True
+    assert zone_climate_state.attributes["open_detector_open_entity_ids"] == [
+        "binary_sensor.living_room_window"
+    ]
+    assert zone_demand_state is not None
+    assert zone_demand_state.state == STATE_OFF
+    assert entry.runtime_data.config.zones[0].enabled is True


### PR DESCRIPTION
## Summary

Adds the door/window detection feature set on top of the current integration branch:

- documents the door/window detector design and issues 020-022
- adds per-zone binary sensor detector configuration
- inhibits zone heating while configured detectors are open without overwriting manual enabled state
- exposes detector configuration, open detector state, unavailable detector state, and inhibition state through diagnostics and zone climate attributes
- expands control logic, coordinator, diagnostics, and entity regression coverage

## Impact

Users can configure door, window, or opening `binary_sensor` entities per zone. When any configured detector is `on`, that zone is temporarily inhibited, stops contributing heat demand, and its actuators follow the existing safe inactive behavior. Closing the final open detector restores normal control if the zone is still manually enabled and global force-off is inactive.

Unavailable detectors are visible in diagnostics but do not inhibit heating in this version.

## Validation

- `PYTHONPATH=. .venv/bin/pytest -q`
- Result: `92 passed`

## Issues

Closes #38 
Closes #39 
Closes #40